### PR TITLE
Add execution timeouts to scheduling functions

### DIFF
--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -53,7 +53,9 @@ class CompilingService:
             legality_result = legality_result.strip()
             if legality_result not in ["0", "1"]:
                 raise Exception(f"Error in legality check: {legality_result}")
-            ast = TiramisuTree.from_isl_ast_string_list(isl_ast_string_list=result_lines[1:])
+            ast = TiramisuTree.from_isl_ast_string_list(
+                isl_ast_string_list=result_lines[1:]
+            )
             return legality_result == "1", ast
 
         else:
@@ -260,7 +262,9 @@ class CompilingService:
         if BaseConfig.base_config is None:
             raise Exception("The base config is not loaded yet")
         legality_cpp_code = cls.get_legality_code(schedule)
-        to_replace = re.findall(r"std::cout << is_legal << std::endl;", legality_cpp_code)[0]
+        to_replace = re.findall(
+            r"std::cout << is_legal << std::endl;", legality_cpp_code
+        )[0]
         header = """
         function * fct = tiramisu::global::get_implicit_function();\n"""
         legality_cpp_code = legality_cpp_code.replace(
@@ -392,6 +396,7 @@ class CompilingService:
         max_runs: int = 0,
         max_mins_per_schedule: float | None = None,
         delete_fiels: bool = True,
+        execution_timeout: float | None = None,
     ) -> List[float]:
         """Return the execution times of the program.
 
@@ -418,7 +423,9 @@ class CompilingService:
         # Get the code of the schedule
         cpp_code = cls.get_schedule_code(tiramisu_program, optims_list)
         # Write the code to a file
-        output_path = os.path.join(BaseConfig.base_config.workspace, tiramisu_program.name)
+        output_path = os.path.join(
+            BaseConfig.base_config.workspace, tiramisu_program.name
+        )
 
         cls.write_to_disk(cpp_code, output_path + "_schedule")
 
@@ -427,13 +434,19 @@ class CompilingService:
             with open(output_path + "_wrapper", "wb") as f:
                 f.write(tiramisu_program.wrapper_obj)
             # write the wrapper header file needed by the schedule file
-            cls.write_to_disk(tiramisu_program.wrappers["h"], output_path + "_wrapper", ".h")
+            cls.write_to_disk(
+                tiramisu_program.wrappers["h"], output_path + "_wrapper", ".h"
+            )
             # give it execution rights to be able to run it
             subprocess.check_output(["chmod", "+x", output_path + "_wrapper"])
         else:
             # write the wrappers
-            cls.write_to_disk(tiramisu_program.wrappers["cpp"], output_path + "_wrapper")
-            cls.write_to_disk(tiramisu_program.wrappers["h"], output_path + "_wrapper", ".h")
+            cls.write_to_disk(
+                tiramisu_program.wrappers["cpp"], output_path + "_wrapper"
+            )
+            cls.write_to_disk(
+                tiramisu_program.wrappers["h"], output_path + "_wrapper", ".h"
+            )
 
         env_vars = CompilingService.get_env_vars()
 
@@ -481,6 +494,7 @@ class CompilingService:
                     text=True,
                     shell=True,
                     check=True,
+                    timeout=execution_timeout,
                 )
 
                 if compiler.stdout:
@@ -509,6 +523,7 @@ class CompilingService:
                 text=True,
                 shell=True,
                 check=True,
+                timeout=execution_timeout,
             )
 
             # Extract the execution times from the output and return the min
@@ -530,8 +545,6 @@ class CompilingService:
             raise ScheduleExecutionError(
                 f"Schedule execution crashed: function: {tiramisu_program.name}, schedule: {optims_list}"  # noqa: E501
             )
-        except Exception as e:
-            raise e
 
     @classmethod
     def get_n_runs_script(
@@ -566,7 +579,8 @@ class CompilingService:
             raise ValueError("BaseConfig not initialized")
 
         env_vars = [
-            f"export {key}={value}" for key, value in BaseConfig.base_config.env_vars.items()
+            f"export {key}={value}"
+            for key, value in BaseConfig.base_config.env_vars.items()
         ]
 
         libs = ":".join(BaseConfig.base_config.dependencies.libs)

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -84,6 +84,7 @@ class Schedule:
         nb_exec_times=1,
         max_mins_per_schedule: float | None = None,
         delete_files: bool = True,
+        execution_timeout: float | None = None,
     ) -> List[float]:
         """
         Applies the schedule to the Tiramisu program.
@@ -123,6 +124,7 @@ class Schedule:
             nb_exec_times,
             max_mins_per_schedule,
             delete_files,
+            execution_timeout,
         )
 
     def is_legal(self, with_ast: bool = False) -> bool:


### PR DESCRIPTION
## TLDR

Introduce timeouts for schedule execution to enhance control over execution duration. This change allows specifying an execution timeout parameter in the `execute` function.

## Summary:
This pull request includes several changes to the `tiralib/tiramisu/compiling_service.py` and `tiralib/tiramisu/schedule.py` files, focusing on code formatting improvements and adding a new parameter for execution timeout.

### Code Formatting Improvements:
* [`tiralib/tiramisu/compiling_service.py`](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L56-R58): Reformatted code blocks to improve readability by splitting long lines into multiple lines. [[1]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L56-R58) [[2]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L263-R267) [[3]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L421-R428) [[4]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L430-R449) [[5]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L569-R583)
* [`tiralib/tiramisu/schedule.py`](diffhunk://#diff-d8fa3bc539b578032c95949c268a80813b36566fc959caac876cf0f2c48d96efR127): Reformatted code blocks to improve readability by splitting long lines into multiple lines.

### New Parameter Addition:
* [`tiralib/tiramisu/compiling_service.py`](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07R399): Added `execution_timeout` parameter to the `get_cpu_exec_times` method and updated subprocess calls to include the timeout. [[1]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07R399) [[2]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07R497) [[3]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07R526)
* [`tiralib/tiramisu/schedule.py`](diffhunk://#diff-d8fa3bc539b578032c95949c268a80813b36566fc959caac876cf0f2c48d96efR87): Added `execution_timeout` parameter to the `execute` method and updated the call to `get_cpu_exec_times` to pass this parameter. [[1]](diffhunk://#diff-d8fa3bc539b578032c95949c268a80813b36566fc959caac876cf0f2c48d96efR87) [[2]](diffhunk://#diff-d8fa3bc539b578032c95949c268a80813b36566fc959caac876cf0f2c48d96efR127)

### Exception Handling:
* [`tiralib/tiramisu/compiling_service.py`](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L533-L534): Removed redundant exception handling code in the `get_cpu_exec_times` method.Introduce timeouts for schedule execution to enhance control over execution duration. This change allows specifying an execution timeout parameter in relevant functions.