### PR TITLE
Use Local Logger and Fix Crash with Single-Iteration Loops

### DIFF
--- a/tiralib/__init__.py
+++ b/tiralib/__init__.py
@@ -1,1 +1,8 @@
 """TiraLib."""
+
+import logging
+
+logger = logging.getLogger("TiraLib")
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(logging.Formatter("|%(asctime)s|%(levelname)s| %(message)s"))
+logger.addHandler(console_handler)

--- a/tiralib/__init__.py
+++ b/tiralib/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-logger = logging.getLogger("TiraLib")
+logger = logging.getLogger(__name__)
 console_handler = logging.StreamHandler()
 console_handler.setFormatter(logging.Formatter("|%(asctime)s|%(levelname)s| %(message)s"))
 logger.addHandler(console_handler)

--- a/tiralib/config.py
+++ b/tiralib/config.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 import yaml
 
+logger = logging.getLogger("TiraLib")
 
 @dataclass
 class TiraLibCppConfig:
@@ -76,16 +77,13 @@ class BaseConfig:
         """Initialize the config."""
         parsed_yaml_dict = parse_yaml_file(read_yaml_file(config_yaml))
         BaseConfig.base_config = dict_to_config(parsed_yaml_dict)
-        logging.basicConfig(
-            level=logging_level,
-            format="|%(asctime)s|%(levelname)s| %(message)s",
-        )
+        
+        logger.setLevel(logging_level)
 
     @classmethod
     def from_tiralib_config(cls, tiralib_config: TiraLibConfig, logging_level=logging.DEBUG):
         """Initialize the config from a TiraLibConfig object."""
         BaseConfig.base_config = tiralib_config
-        logging.basicConfig(
-            level=logging_level,
-            format="|%(asctime)s|%(levelname)s| %(message)s",
-        )
+        
+        logger.setLevel(logging_level)
+

--- a/tiralib/config.py
+++ b/tiralib/config.py
@@ -6,7 +6,6 @@ from typing import Any, Dict
 
 import yaml
 
-logger = logging.getLogger("TiraLib")
 
 @dataclass
 class TiraLibCppConfig:
@@ -77,13 +76,13 @@ class BaseConfig:
         """Initialize the config."""
         parsed_yaml_dict = parse_yaml_file(read_yaml_file(config_yaml))
         BaseConfig.base_config = dict_to_config(parsed_yaml_dict)
-        
-        logger.setLevel(logging_level)
+        base_logger = logging.getLogger(__name__.split('.')[0])
+        base_logger.setLevel(logging_level)
 
     @classmethod
     def from_tiralib_config(cls, tiralib_config: TiraLibConfig, logging_level=logging.DEBUG):
         """Initialize the config from a TiraLibConfig object."""
         BaseConfig.base_config = tiralib_config
-        
-        logger.setLevel(logging_level)
+        base_logger = logging.getLogger(__name__.split('.')[0])
+        base_logger.setLevel(logging_level)
 

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from tiralib.tiramisu.tiramisu_actions.tiramisu_action import TiramisuAction
     from tiralib.tiramisu.tiramisu_program import TiramisuProgram
 
-logger = logging.getLogger("TiraLib")
+logger = logging.getLogger(__name__)
 
 class CompilingService:
     """Compile Tiramisu code and run it to get the results.

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from tiralib.tiramisu.tiramisu_actions.tiramisu_action import TiramisuAction
     from tiralib.tiramisu.tiramisu_program import TiramisuProgram
 
+logger = logging.getLogger("TiraLib")
 
 class CompilingService:
     """Compile Tiramisu code and run it to get the results.
@@ -43,7 +44,7 @@ class CompilingService:
 
         cpp_code = cls.get_legality_code(schedule=schedule, with_ast=with_ast)
 
-        logging.debug("Legality Code: \n" + cpp_code)
+        logger.debug("Legality Code: \n" + cpp_code)
 
         result = cls.run_cpp_code(cpp_code=cpp_code, output_path=output_path)
 
@@ -230,9 +231,9 @@ class CompilingService:
                 raise Exception("Compiler returned no output")
 
         except subprocess.CalledProcessError as e:
-            logging.error(f"Process terminated with error code: {e.returncode}")
-            logging.error(f"Error output: {e.stderr}")
-            logging.error(env_vars + shell_script)
+            logger.error(f"Process terminated with error code: {e.returncode}")
+            logger.error(f"Error output: {e.stderr}")
+            logger.error(env_vars + shell_script)
             raise e
         except Exception as e:
             raise e
@@ -314,7 +315,7 @@ class CompilingService:
             """
 
         solver_code = legality_cpp_code.replace(to_replace, solver_lines)
-        logging.debug("Skewing Solver Code:\n" + solver_code)
+        logger.debug("Skewing Solver Code:\n" + solver_code)
         output_path = os.path.join(
             BaseConfig.base_config.workspace,
             f"{schedule.tiramisu_program.name}_skewing_solver",
@@ -464,7 +465,7 @@ class CompilingService:
             )
 
             halide_repr = compiler.stdout
-            logging.debug(f"Generated Halide code:\n{halide_repr}")
+            logger.debug(f"Generated Halide code:\n{halide_repr}")
 
             if max_mins_per_schedule:
                 # run the wrapper and get the execution time
@@ -516,17 +517,17 @@ class CompilingService:
                 results += [float(x) for x in compiler.stdout.split()]
                 return results
             else:
-                logging.error("No output from schedule execution")
-                logging.error(compiler.stderr)
-                logging.error(compiler.stdout)
-                logging.error(
+                logger.error("No output from schedule execution")
+                logger.error(compiler.stderr)
+                logger.error(compiler.stdout)
+                logger.error(
                     f"The following schedule execution crashed: {tiramisu_program.name}, schedule: {optims_list} \n\n {cpp_code}\n\n"  # noqa: E501
                 )
                 raise ScheduleExecutionError("No output from schedule execution")
         except subprocess.CalledProcessError as e:
-            logging.error(f"Process terminated with error code: {e.returncode}")
-            logging.error(f"Error output: {e.stderr}")
-            logging.error(f"Output: {e.stdout}")
+            logger.error(f"Process terminated with error code: {e.returncode}")
+            logger.error(f"Error output: {e.stderr}")
+            logger.error(f"Output: {e.stdout}")
             raise ScheduleExecutionError(
                 f"Schedule execution crashed: function: {tiramisu_program.name}, schedule: {optims_list}"  # noqa: E501
             )

--- a/tiralib/tiramisu/function_server.py
+++ b/tiralib/tiramisu/function_server.py
@@ -10,6 +10,8 @@ from tiralib.config import BaseConfig
 if TYPE_CHECKING:
     from tiralib.tiramisu.schedule import Schedule
     from tiralib.tiramisu.tiramisu_program import TiramisuProgram
+    
+logger = logging.getLogger("TiraLib")
 
 templateWithEverythinginUtils = """
 #include <tiramisu/tiramisu.h>
@@ -114,7 +116,7 @@ class FunctionServer:
         server_path = Path(BaseConfig.base_config.workspace) / f"{tiramisu_program.name}_server"
 
         if reuse_server and server_path.exists():
-            logging.info("Server code already exists. Skipping generation")
+            logger.info("Server code already exists. Skipping generation")
             return
 
         # Generate the server code
@@ -185,8 +187,8 @@ class FunctionServer:
         try:
             subprocess.check_output(compile_command, shell=True)
         except subprocess.CalledProcessError as e:
-            logging.error(f"Error while compiling server code: {e}")
-            logging.error(e.output)
+            logger.error(f"Error while compiling server code: {e}")
+            logger.error(e.output)
             print(e.output)
             print(e.stderr)
             raise e
@@ -220,8 +222,8 @@ class FunctionServer:
         try:
             output = subprocess.check_output(command, shell=True)
         except subprocess.CalledProcessError as e:
-            logging.error(f"Error while running server code: {e}")
-            logging.error(e.output)
+            logger.error(f"Error while running server code: {e}")
+            logger.error(e.output)
             print(e.output)
             print(e.stderr)
             raise e
@@ -245,8 +247,8 @@ class FunctionServer:
         try:
             output = subprocess.check_output(command, shell=True)
         except subprocess.CalledProcessError as e:
-            logging.error(f"Error while running server code: {e}")
-            logging.error(e.output)
+            logger.error(f"Error while running server code: {e}")
+            logger.error(e.output)
             print(e.output)
             print(e.stderr)
             raise e

--- a/tiralib/tiramisu/function_server.py
+++ b/tiralib/tiramisu/function_server.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from tiralib.tiramisu.schedule import Schedule
     from tiralib.tiramisu.tiramisu_program import TiramisuProgram
     
-logger = logging.getLogger("TiraLib")
+logger = logging.getLogger(__name__)
 
 templateWithEverythinginUtils = """
 #include <tiramisu/tiramisu.h>

--- a/tiralib/tiramisu/tiramisu_tree.py
+++ b/tiralib/tiramisu/tiramisu_tree.py
@@ -219,9 +219,13 @@ class TiramisuTree:
 
                 # Add the computation to its iterator's computations list
                 # (the last iterator we added in the previous level)
-                tiramisu_tree.iterators[
-                    level_iterator_map[level - 1][-1]
-                ].computations_list.append(comp_name)
+                # After making sure that the computation is in an actual loop. 
+                # Some computations might occur in a single iteration loop which
+                # would be romved by ISL
+                if level!=0: 
+                    tiramisu_tree.iterators[
+                        level_iterator_map[level - 1][-1]
+                    ].computations_list.append(comp_name)
 
                 # Add the computation to the absolute order dict
                 tiramisu_tree.computations_absolute_order[comp_name] = i


### PR DESCRIPTION
### Summary of Changes

1. **Switched to Local Logger**
    Updated TiraLib to use its own local logger instead of the root logger. This keeps TiraLib's logging separate from other imported modules, avoiding any unexpected settings interference.
    _Related commits:_ [Commit 1](https://github.com/Mascinissa/TiraLib/commit/517e2c201f1ed928c53ad2e211f29a12d1409e61), [Commit 2](https://github.com/Mascinissa/TiraLib/commit/9b9e1f250af765d497495a26ae2cfc0bed34528e)

2. **Fixed Bug with Single-Iteration Loops in ISL Tree Construction**
    Addressed a bug occurring when constructing a tree from ISL for programs containing single-iteration loops. ISL’s simplification pass skips such loops, rendering their computations "loopless" which previously caused TiraLib to crash when attempting to identify a parent loop. An example of such programs is [PolyBench's correlation kernel](https://github.com/Tiramisu-Compiler/tiramisu/blob/merge_attempt/benchmarks/autoscheduler_benchmarks/polybench/MEDIUM/function_correlation_MEDIUM/function_correlation_MEDIUM_generator.cpp).
    _Solution:_ Modified TiraLib to also skip these computations, as they are not involved in transformations or legality checking anyways.
    _Related commit:_ [Commit](https://github.com/Mascinissa/TiraLib/commit/241a27d53a7467c02c13a2e3fc634e0e8427e120)