### PR TITLE
added check format code to ci and seperated jobs for fast failures

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -27,9 +27,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,8 +6,40 @@ name: Python package
 on: [push, pull_request]
 
 jobs:
-  build:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.10
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ruff
+    - name: Check formating with ruff
+      run: |
+        ruff format --check
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.10
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ruff
+    - name: Lint with ruff
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        ruff check
+  
+  build:
     runs-on: ubuntu-latest
     container:
       image: skourta/tiramisu:latest
@@ -18,19 +50,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install ruff pytest pytest-cov coverage
         if [ -f requirements.txt ]; then python -m pip install --user -r requirements.txt; fi
-    - name: Lint with ruff
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        ruff check
+
     - name: Install TiraLibCPP
       run: |
         apt install -y sqlite3 libsqlite3-dev zlib1g-dev
@@ -39,6 +70,7 @@ jobs:
         cmake . -B build -DTIRAMISU_INSTALL=${INSTALL_PATH}
         cmake --build build
         cmake --install build --prefix ${INSTALL_PATH}
+
     - name: Create config.yaml
       run: |
         mkdir workspace
@@ -50,6 +82,7 @@ jobs:
         echo "    - ${INSTALL_PATH}/include" >> config.yaml
         echo "  libs:" >> config.yaml
         echo "    - ${INSTALL_PATH}/lib" >> config.yaml
+
     - name: Test with pytest
       run: |
         pytest

--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -117,7 +117,9 @@ def test_from_sched_str():
 
     schedule.add_optimizations(
         [
-            tiramisu_actions.Tiling3D([("comp00", 0), ("comp00", 1), ("comp00", 2), 4, 4, 4]),
+            tiramisu_actions.Tiling3D(
+                [("comp00", 0), ("comp00", 1), ("comp00", 2), 4, 4, 4]
+            ),
         ]
     )
 

--- a/tests/tiramisu/test_tiramisu_server.py
+++ b/tests/tiramisu/test_tiramisu_server.py
@@ -95,7 +95,9 @@ def test_get_skewing_factors():
 
     schedule = Schedule(tiramisu_func)
 
-    schedule.add_optimizations([tiramisu_actions.Skewing([("comp00", 0), ("comp00", 1), 0, 0])])
+    schedule.add_optimizations(
+        [tiramisu_actions.Skewing([("comp00", 0), ("comp00", 1), 0, 0])]
+    )
 
     assert schedule.is_legal()
 

--- a/tests/tiramisu/tiramisu_actions/test_distribution.py
+++ b/tests/tiramisu/tiramisu_actions/test_distribution.py
@@ -101,7 +101,9 @@ def test_get_fusion_levels():
     ]
 
     t_tree = test_utils.tree_test_sample_2()
-    distribution = Distribution([("comp05", 1)], [["comp05", "comp06"], ["comp07", ("comp03", 2)]])
+    distribution = Distribution(
+        [("comp05", 1)], [["comp05", "comp06"], ["comp07", ("comp03", 2)]]
+    )
     distribution.initialize_action_for_tree(t_tree)
     ordered_computations = t_tree.computations
     ordered_computations.sort(key=lambda x: t_tree.computations_absolute_order[x])

--- a/tests/tiramisu/tiramisu_actions/test_expansion.py
+++ b/tests/tiramisu/tiramisu_actions/test_expansion.py
@@ -43,5 +43,7 @@ def test_expansion_application():
     assert not schedule.is_legal()
 
     schedule = Schedule(sample)
-    schedule.add_optimizations([Expansion(["addition"]), Parallelization([("addition", 1)])])
+    schedule.add_optimizations(
+        [Expansion(["addition"]), Parallelization([("addition", 1)])]
+    )
     assert schedule.is_legal()

--- a/tests/tiramisu/tiramisu_actions/test_matrix.py
+++ b/tests/tiramisu/tiramisu_actions/test_matrix.py
@@ -29,7 +29,10 @@ def test_set_string_representations():
     matrix = MatrixTransform([1, 0, 0, 0, 0, 1, 0, 1, 0], ["comp00"])
     schedule = Schedule(sample)
     schedule.add_optimizations([matrix])
-    assert matrix.tiramisu_optim_str == "comp00.matrix_transform({{1,0,0},{0,0,1},{0,1,0}});"
+    assert (
+        matrix.tiramisu_optim_str
+        == "comp00.matrix_transform({{1,0,0},{0,0,1},{0,1,0}});"
+    )
 
 
 def test_legality_check():

--- a/tests/tiramisu/tiramisu_actions/test_tiling_general.py
+++ b/tests/tiramisu/tiramisu_actions/test_tiling_general.py
@@ -19,7 +19,9 @@ def test_tiling_general_init():
 def test_initialize_action_for_tree():
     BaseConfig.init()
     sample = test_utils.gramschmidt_sample()
-    tiling_general = TilingGeneral([("R_up_init", 1), ("R_up", 2), ("A_out", 2), 10, 10, 10])
+    tiling_general = TilingGeneral(
+        [("R_up_init", 1), ("R_up", 2), ("A_out", 2), 10, 10, 10]
+    )
     tiling_general.initialize_action_for_tree(sample.tree)
     assert tiling_general.iterators == [
         ("R_up_init", 1),
@@ -38,7 +40,9 @@ def test_initialize_action_for_tree():
 def test_set_string_representations():
     BaseConfig.init()
     sample = test_utils.gramschmidt_sample()
-    tiling_general = TilingGeneral([("R_up_init", 1), ("R_up", 2), ("A_out", 2), 10, 5, 2])
+    tiling_general = TilingGeneral(
+        [("R_up_init", 1), ("R_up", 2), ("A_out", 2), 10, 5, 2]
+    )
     tiling_general.initialize_action_for_tree(sample.tree)
     assert tiling_general.iterators == [
         ("R_up_init", 1),

--- a/tiralib/__init__.py
+++ b/tiralib/__init__.py
@@ -4,5 +4,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 console_handler = logging.StreamHandler()
-console_handler.setFormatter(logging.Formatter("|%(asctime)s|%(levelname)s| %(message)s"))
+console_handler.setFormatter(
+    logging.Formatter("|%(asctime)s|%(levelname)s| %(message)s")
+)
 logger.addHandler(console_handler)

--- a/tiralib/config.py
+++ b/tiralib/config.py
@@ -60,7 +60,9 @@ def dict_to_config(parsed_yaml: Dict[Any, Any]) -> TiraLibConfig:
     )
     return TiraLibConfig(
         max_runs=parsed_yaml["max_runs"] if "max_runs" in parsed_yaml else 30,
-        workspace=parsed_yaml["workspace"] if "workspace" in parsed_yaml else "workspace",
+        workspace=parsed_yaml["workspace"]
+        if "workspace" in parsed_yaml
+        else "workspace",
         env_vars=env_vars,
         tiralib_cpp=tiralibcpp,
         dependencies=deps,
@@ -77,15 +79,16 @@ class BaseConfig:
         """Initialize the config."""
         parsed_yaml_dict = parse_yaml_file(read_yaml_file(config_yaml))
         BaseConfig.base_config = dict_to_config(parsed_yaml_dict)
-        base_logger = logging.getLogger(__name__.split('.')[0])
+        base_logger = logging.getLogger(__name__.split(".")[0])
         base_logger.setLevel(logging_level)
         Path(BaseConfig.base_config.workspace).mkdir(parents=True, exist_ok=True)
 
     @classmethod
-    def from_tiralib_config(cls, tiralib_config: TiraLibConfig, logging_level=logging.DEBUG):
+    def from_tiralib_config(
+        cls, tiralib_config: TiraLibConfig, logging_level=logging.DEBUG
+    ):
         """Initialize the config from a TiraLibConfig object."""
         BaseConfig.base_config = tiralib_config
-        base_logger = logging.getLogger(__name__.split('.')[0])
+        base_logger = logging.getLogger(__name__.split(".")[0])
         base_logger.setLevel(logging_level)
         Path(BaseConfig.base_config.workspace).mkdir(parents=True, exist_ok=True)
-

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 class CompilingService:
     """Compile Tiramisu code and run it to get the results.
 

--- a/tiralib/tiramisu/function_server.py
+++ b/tiralib/tiramisu/function_server.py
@@ -10,7 +10,7 @@ from tiralib.config import BaseConfig
 if TYPE_CHECKING:
     from tiralib.tiramisu.schedule import Schedule
     from tiralib.tiramisu.tiramisu_program import TiramisuProgram
-    
+
 logger = logging.getLogger(__name__)
 
 templateWithEverythinginUtils = """
@@ -110,30 +110,37 @@ class FunctionServer:
         self.tiramisu_program = tiramisu_program
 
         server_path_cpp = (
-            Path(BaseConfig.base_config.workspace) / f"{tiramisu_program.name}_server.cpp"
+            Path(BaseConfig.base_config.workspace)
+            / f"{tiramisu_program.name}_server.cpp"
         )
 
-        server_path = Path(BaseConfig.base_config.workspace) / f"{tiramisu_program.name}_server"
+        server_path = (
+            Path(BaseConfig.base_config.workspace) / f"{tiramisu_program.name}_server"
+        )
 
         if reuse_server and server_path.exists():
             logger.info("Server code already exists. Skipping generation")
             return
 
         # Generate the server code
-        server_code = FunctionServer._generate_server_code_from_original_string(tiramisu_program)
+        server_code = FunctionServer._generate_server_code_from_original_string(
+            tiramisu_program
+        )
 
         # Write the server code to a file
         server_path_cpp.write_text(server_code)
 
         # Write the wrapper code to a file
         wrapper_path = (
-            Path(BaseConfig.base_config.workspace) / f"{tiramisu_program.name}_wrapper.cpp"
+            Path(BaseConfig.base_config.workspace)
+            / f"{tiramisu_program.name}_wrapper.cpp"
         )
         wrapper_path.write_text(tiramisu_program.wrappers["cpp"])
 
         # Write the wrapper header to a file
         wrapper_header_path = (
-            Path(BaseConfig.base_config.workspace) / f"{tiramisu_program.name}_wrapper.h"
+            Path(BaseConfig.base_config.workspace)
+            / f"{tiramisu_program.name}_wrapper.h"
         )
 
         wrapper_header_path.write_text(tiramisu_program.wrappers["h"])
@@ -142,7 +149,9 @@ class FunctionServer:
         self._compile_server_code()
 
     @classmethod
-    def _generate_server_code_from_original_string(self, tiramisu_program: "TiramisuProgram"):
+    def _generate_server_code_from_original_string(
+        self, tiramisu_program: "TiramisuProgram"
+    ):
         original_str = tiramisu_program.original_str
         if original_str is None:
             raise ValueError("Original string not initialized")
@@ -155,7 +164,9 @@ class FunctionServer:
         # Remove the wrapper include from the original string
         wrapper_str = f'#include "{name}_wrapper.h"'
         original_str = original_str.replace(wrapper_str, f"// {wrapper_str}")
-        buffers_vector = re.findall(r"(?<=tiramisu::codegen\()\{[&\w,\s]+\}", original_str)[0]
+        buffers_vector = re.findall(
+            r"(?<=tiramisu::codegen\()\{[&\w,\s]+\}", original_str
+        )[0]
 
         # fill the template
         function_str = templateWithEverythinginUtils.format(
@@ -172,12 +183,17 @@ class FunctionServer:
 
         libs = ":".join(BaseConfig.base_config.dependencies.libs)
         env_vars = " && ".join(
-            [f"export {key}={value}" for key, value in BaseConfig.base_config.env_vars.items()]
+            [
+                f"export {key}={value}"
+                for key, value in BaseConfig.base_config.env_vars.items()
+            ]
         )
 
         env_vars += f" && export LD_LIBRARY_PATH={libs}:$LD_LIBRARY_PATH"
         env_vars += f" && export LIBRARY_PATH={libs}:$LIBRARY_PATH"
-        env_vars += f" && export CPATH={':'.join(BaseConfig.base_config.dependencies.includes)}"
+        env_vars += (
+            f" && export CPATH={':'.join(BaseConfig.base_config.dependencies.includes)}"
+        )
 
         libs = ":".join(BaseConfig.base_config.dependencies.libs)
 
@@ -202,19 +218,27 @@ class FunctionServer:
         """Run the server code."""
         if not BaseConfig.base_config:
             raise ValueError("BaseConfig not initialized")
-        assert operation in [
-            "execution",
-            "legality",
-        ], f"Invalid operation {operation}. Valid operations are: execution, legality, annotations"  # noqa: E501
+        assert (
+            operation
+            in [
+                "execution",
+                "legality",
+            ]
+        ), f"Invalid operation {operation}. Valid operations are: execution, legality, annotations"  # noqa: E501
 
         env_vars = " && ".join(
-            [f"export {key}={value}" for key, value in BaseConfig.base_config.env_vars.items()]
+            [
+                f"export {key}={value}"
+                for key, value in BaseConfig.base_config.env_vars.items()
+            ]
         )
 
         libs = ":".join(BaseConfig.base_config.dependencies.libs)
         env_vars += f" && export LD_LIBRARY_PATH={libs}:$LD_LIBRARY_PATH"
         env_vars += f" && export LIBRARY_PATH={libs}:$LIBRARY_PATH"
-        env_vars += f" && export CPATH={':'.join(BaseConfig.base_config.dependencies.includes)}"
+        env_vars += (
+            f" && export CPATH={':'.join(BaseConfig.base_config.dependencies.includes)}"
+        )
 
         command = f'{env_vars} && cd {BaseConfig.base_config.workspace} && NB_EXEC={nbr_executions} ./{self.tiramisu_program.name}_server {operation} "{schedule or ""}"'  # noqa: E501
 
@@ -234,12 +258,17 @@ class FunctionServer:
         if not BaseConfig.base_config:
             raise ValueError("BaseConfig not initialized")
         env_vars = " && ".join(
-            [f"export {key}={value}" for key, value in BaseConfig.base_config.env_vars.items()]
+            [
+                f"export {key}={value}"
+                for key, value in BaseConfig.base_config.env_vars.items()
+            ]
         )
         libs = ":".join(BaseConfig.base_config.dependencies.libs)
         env_vars += f" && export LD_LIBRARY_PATH={libs}:$LD_LIBRARY_PATH"
         env_vars += f" && export LIBRARY_PATH={libs}:$LIBRARY_PATH"
-        env_vars += f" && export CPATH={':'.join(BaseConfig.base_config.dependencies.includes)}"
+        env_vars += (
+            f" && export CPATH={':'.join(BaseConfig.base_config.dependencies.includes)}"
+        )
 
         command = f"{env_vars} && cd {BaseConfig.base_config.workspace} && ./{self.tiramisu_program.name}_server annotations"  # noqa: E501
 

--- a/tiralib/tiramisu/tiramisu_actions/expansion.py
+++ b/tiralib/tiramisu/tiramisu_actions/expansion.py
@@ -55,7 +55,9 @@ class Expansion(TiramisuAction):
             candidates_code += "    " + optim.tiramisu_optim_str
 
         for comp in schedule.tree.computations:
-            candidates_code += f'    std::cout << "{comp}|" << {comp}.expandable() << std::endl;\n'  # noqa
+            candidates_code += (
+                f'    std::cout << "{comp}|" << {comp}.expandable() << std::endl;\n'  # noqa
+            )
 
         cpp_code = schedule.tiramisu_program.original_str.replace(
             schedule.tiramisu_program.code_gen_line, candidates_code

--- a/tiralib/tiramisu/tiramisu_program.py
+++ b/tiralib/tiramisu/tiramisu_program.py
@@ -89,7 +89,9 @@ class TiramisuProgram:
         tiramisu_prog.wrappers = {"cpp": wrapper_cpp, "h": wrapper_header}
 
         if load_tree:
-            tiramisu_prog.tree = TiramisuTree.from_annotations(tiramisu_prog.annotations)
+            tiramisu_prog.tree = TiramisuTree.from_annotations(
+                tiramisu_prog.annotations
+            )
         return tiramisu_prog
 
     @classmethod
@@ -130,12 +132,16 @@ class TiramisuProgram:
                 CompilingService.compile_annotations(tiramisu_prog)
             )
         elif load_isl_ast:
-            tiramisu_prog.isl_ast_string = CompilingService.compile_isl_ast_tree(tiramisu_prog)
+            tiramisu_prog.isl_ast_string = CompilingService.compile_isl_ast_tree(
+                tiramisu_prog
+            )
 
         if load_tree:
             if tiramisu_prog.annotations:
                 assert tiramisu_prog.annotations is not None
-                tiramisu_prog.tree = TiramisuTree.from_annotations(tiramisu_prog.annotations)
+                tiramisu_prog.tree = TiramisuTree.from_annotations(
+                    tiramisu_prog.annotations
+                )
             elif tiramisu_prog.isl_ast_string:
                 tiramisu_prog.tree = TiramisuTree.from_isl_ast_string_list(
                     tiramisu_prog.isl_ast_string.split("\n")
@@ -183,7 +189,9 @@ class TiramisuProgram:
         if load_tree:
             if tiramisu_prog.annotations:
                 assert tiramisu_prog.annotations is not None
-                tiramisu_prog.tree = TiramisuTree.from_annotations(tiramisu_prog.annotations)
+                tiramisu_prog.tree = TiramisuTree.from_annotations(
+                    tiramisu_prog.annotations
+                )
             elif tiramisu_prog.isl_ast_string:
                 tiramisu_prog.tree = TiramisuTree.from_isl_ast_string_list(
                     tiramisu_prog.isl_ast_string.split("\n")
@@ -219,14 +227,20 @@ class TiramisuProgram:
         self.name = re.findall(r"tiramisu::init\(\"(\w+)\"\);", self.original_str)[0]
         # Remove the wrapper include from the original string
         self.wrapper_str = f'#include "{self.name}_wrapper.h"'
-        self.original_str = self.original_str.replace(self.wrapper_str, f"// {self.wrapper_str}")
+        self.original_str = self.original_str.replace(
+            self.wrapper_str, f"// {self.wrapper_str}"
+        )
         self.comps = re.findall(r"computation (\w+)\(", self.original_str)
-        self.code_gen_line = re.findall(r"tiramisu::codegen\({.+;", self.original_str)[0]
+        self.code_gen_line = re.findall(r"tiramisu::codegen\({.+;", self.original_str)[
+            0
+        ]
         buffers_vect = re.findall(r"{(.+)}", self.code_gen_line)[0]
         self.IO_buffer_names = re.findall(r"\w+", buffers_vect)
         self.buffer_sizes = []
         for buf_name in self.IO_buffer_names:
-            sizes_vect = re.findall(r"buffer " + buf_name + ".*{(.*)}", self.original_str)[0]
+            sizes_vect = re.findall(
+                r"buffer " + buf_name + ".*{(.*)}", self.original_str
+            )[0]
             self.buffer_sizes.append(re.findall(r"\d+", sizes_vect))
         self.wrapper_is_compiled = False
 
@@ -244,8 +258,12 @@ class TiramisuProgram:
             raise Exception("TiramisuProgram.name is None")
 
         wrapper_cpp_code = wrapper_cpp_template.replace("$func_name$", self.name)
-        wrapper_cpp_code = wrapper_cpp_code.replace("$buffers_init$", buffers_init_lines)
-        wrapper_cpp_code = wrapper_cpp_code.replace("$func_folder_path$", self.func_folder)
+        wrapper_cpp_code = wrapper_cpp_code.replace(
+            "$buffers_init$", buffers_init_lines
+        )
+        wrapper_cpp_code = wrapper_cpp_code.replace(
+            "$func_folder_path$", self.func_folder
+        )
         wrapper_cpp_code = wrapper_cpp_code.replace(
             "$func_params$",
             ",".join([name + ".raw_buffer()" for name in self.IO_buffer_names]),

--- a/tiralib/tiramisu/tiramisu_tree.py
+++ b/tiralib/tiramisu/tiramisu_tree.py
@@ -219,10 +219,10 @@ class TiramisuTree:
 
                 # Add the computation to its iterator's computations list
                 # (the last iterator we added in the previous level)
-                # After making sure that the computation is in an actual loop. 
+                # After making sure that the computation is in an actual loop.
                 # Some computations might occur in a single iteration loop which
                 # would be romved by ISL
-                if level!=0: 
+                if level != 0:
                     tiramisu_tree.iterators[
                         level_iterator_map[level - 1][-1]
                     ].computations_list.append(comp_name)


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow for the Python package. The changes focus on splitting the workflow into separate jobs for formatting, linting, and building, as well as updating dependencies and configurations.

### Workflow Improvements:

* [`.github/workflows/python-package.yml`](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L9-R42): Split the workflow into three separate jobs: `format`, `lint`, and `build`, to improve clarity and maintainability.
* [`.github/workflows/python-package.yml`](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320R53-R64): Updated the `setup-python` action to version 5 for all jobs to ensure compatibility with the latest features and improvements.

### Dependency Management:

* [`.github/workflows/python-package.yml`](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L9-R42): Added steps to install `ruff` for both formatting and linting checks, ensuring consistent code style and quality. [[1]](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L9-R42) [[2]](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320R53-R64)

### Build Configuration:

* [`.github/workflows/python-package.yml`](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L9-R42): Retained the `build` job with necessary steps for setting up the environment, installing dependencies, and building the project. [[1]](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L9-R42) [[2]](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320R53-R64)

### Testing:

* [`.github/workflows/python-package.yml`](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320R85): Ensured that the `build` job includes a step for running tests with `pytest` to validate the code changes.