### PR TITLE
Improving Schedule.execute Time-Budget Handling

### DIFF
--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -24,9 +24,9 @@ def test_min_runs_execution():
     BaseConfig.init()
     test_program = benchmark_program_test_sample()
     schedule = Schedule(test_program)
-    
+
     exec_time = schedule.execute(1)[0]
-    results = schedule.execute(min_runs=10, max_runs=20, time_budget=2*exec_time)
+    results = schedule.execute(min_runs=10, max_runs=20, time_budget=2 * exec_time)
     assert results is not None
     assert len(results) >= 10
 
@@ -36,9 +36,9 @@ def test_time_budget_enforcement():
     BaseConfig.init()
     test_program = benchmark_program_test_sample()
     schedule = Schedule(test_program)
-    
+
     exec_time = schedule.execute(1)[0]
-    time_budget = 5*exec_time
+    time_budget = 5 * exec_time
     results = schedule.execute(min_runs=0, max_runs=20, time_budget=time_budget)
 
     assert results is not None
@@ -51,9 +51,9 @@ def test_max_runs_limitation():
     BaseConfig.init()
     test_program = benchmark_program_test_sample()
     schedule = Schedule(test_program)
-    
+
     exec_time = schedule.execute(1)[0]
-    time_budget = 50*exec_time
+    time_budget = 50 * exec_time
     results = schedule.execute(min_runs=2, max_runs=5, time_budget=time_budget)
 
     assert results is not None
@@ -66,9 +66,9 @@ def test_zero_min_runs():
     BaseConfig.init()
     test_program = benchmark_program_test_sample()
     schedule = Schedule(test_program)
-    
+
     exec_time = schedule.execute(1)[0]
-    time_budget = 0.1*exec_time
+    time_budget = 0.1 * exec_time
     results = schedule.execute(min_runs=0, max_runs=5, time_budget=time_budget)
 
     assert results is not None
@@ -80,14 +80,14 @@ def test_unlimited_max_runs():
     BaseConfig.init()
     test_program = benchmark_program_test_sample()
     schedule = Schedule(test_program)
-    
+
     exec_time = schedule.execute(1)[0]
-    time_budget = 10*exec_time
+    time_budget = 10 * exec_time
     results = schedule.execute(min_runs=0, time_budget=time_budget)
 
     assert results is not None
     assert len(results) > 1
-    assert sum(results) < time_budget 
+    assert sum(results) < time_budget
 
 
 def test_is_legal():

--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -13,7 +13,7 @@ def test_execute():
     schedule = Schedule(test_program)
     assert schedule.tree
     schedule.add_optimizations([Parallelization(params=[("comp02", 0)])])
-    results = schedule.execute(nb_exec_times=10)
+    results = schedule.execute(min_runs=10)
 
     assert results is not None
     assert len(results) == 10

--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -19,6 +19,77 @@ def test_execute():
     assert len(results) == 10
 
 
+def test_min_runs_execution():
+    """Test to ensure the schedule executes at least 'min_runs' times even if the 'time_budget' is insufficient"""
+    BaseConfig.init()
+    test_program = benchmark_program_test_sample()
+    schedule = Schedule(test_program)
+    
+    exec_time = schedule.execute(1)[0]
+    results = schedule.execute(min_runs=10, max_runs=20, time_budget=2*exec_time)
+    assert results is not None
+    assert len(results) >= 10
+
+
+def test_time_budget_enforcement():
+    """Test to verify that execution stops once the 'time_budget' is exhausted, with partial measurements saved."""
+    BaseConfig.init()
+    test_program = benchmark_program_test_sample()
+    schedule = Schedule(test_program)
+    
+    exec_time = schedule.execute(1)[0]
+    time_budget = 5*exec_time
+    results = schedule.execute(min_runs=0, max_runs=20, time_budget=time_budget)
+
+    assert results is not None
+    assert 0 < len(results) < 20
+    assert 0 < sum(results) <= time_budget
+
+
+def test_max_runs_limitation():
+    """Test to ensure the schedule stops executing after 'max_runs' even if the time budget allows more."""
+    BaseConfig.init()
+    test_program = benchmark_program_test_sample()
+    schedule = Schedule(test_program)
+    
+    exec_time = schedule.execute(1)[0]
+    time_budget = 50*exec_time
+    results = schedule.execute(min_runs=2, max_runs=5, time_budget=time_budget)
+
+    assert results is not None
+    assert len(results) == 5
+    assert sum(results) < time_budget
+
+
+def test_zero_min_runs():
+    """Test to ensure proper behavior when 'min_runs' is set to 0, expecting no compulsory runs."""
+    BaseConfig.init()
+    test_program = benchmark_program_test_sample()
+    schedule = Schedule(test_program)
+    
+    exec_time = schedule.execute(1)[0]
+    time_budget = 0.1*exec_time
+    results = schedule.execute(min_runs=0, max_runs=5, time_budget=time_budget)
+
+    assert results is not None
+    assert len(results) == 0
+
+
+def test_unlimited_max_runs():
+    """Test to ensure that, when 'max_runs' is not set, we get as many runs as possible within the time budget."""
+    BaseConfig.init()
+    test_program = benchmark_program_test_sample()
+    schedule = Schedule(test_program)
+    
+    exec_time = schedule.execute(1)[0]
+    time_budget = 10*exec_time
+    results = schedule.execute(min_runs=0, time_budget=time_budget)
+
+    assert results is not None
+    assert len(results) > 1
+    assert sum(results) < time_budget 
+
+
 def test_is_legal():
     BaseConfig.init()
     test_program = benchmark_program_test_sample()

--- a/tiralib/config.py
+++ b/tiralib/config.py
@@ -27,7 +27,6 @@ class Dependencies:
 class TiraLibConfig:
     """Config for TiraLib."""
 
-    max_runs: int = 30
     workspace: str = "workspace"
     env_vars: Dict[str, str] = field(default_factory=dict)
     tiralib_cpp: TiraLibCppConfig = field(default_factory=TiraLibCppConfig)
@@ -59,7 +58,6 @@ def dict_to_config(parsed_yaml: Dict[Any, Any]) -> TiraLibConfig:
         else Dependencies()
     )
     return TiraLibConfig(
-        max_runs=parsed_yaml["max_runs"] if "max_runs" in parsed_yaml else 30,
         workspace=parsed_yaml["workspace"]
         if "workspace" in parsed_yaml
         else "workspace",

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -531,7 +531,7 @@ class CompilingService:
                 consumed_time = sum(results)
                 if consumed_time >= time_budget:
                     logger.debug(
-                        f'No time budget left to perform extra runs. Consumed time:{consumed_time} >= time budget:{time_budget}. Completed {len(results)} out of {min_runs} min_runs and 0 out of {max_runs-min_runs if max_runs else 'inf'} extra runs.'
+                        f"No time budget left to perform extra runs. Consumed time:{consumed_time} >= time budget:{time_budget}. Completed {len(results)} out of {min_runs} min_runs and 0 out of {max_runs-min_runs if max_runs else 'inf'} extra runs."
                     )
                 # if a time_budget is set and hasn't been consumed by the min_runs
                 else:

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -471,7 +471,7 @@ class CompilingService:
         try:
             # run the compilation of the generator and wrapper
             compiler = subprocess.run(
-                [" ; ".join(env_vars + shell_script)],
+                [" && ".join(env_vars + shell_script)],
                 capture_output=True,
                 text=True,
                 shell=True,
@@ -485,7 +485,7 @@ class CompilingService:
                 # run the wrapper and get the execution time
                 compiler = subprocess.run(
                     [
-                        " ; ".join(
+                        " && ".join(
                             env_vars
                             + CompilingService.get_n_runs_script(
                                 max_runs=1, tiramisu_program=tiramisu_program
@@ -512,7 +512,7 @@ class CompilingService:
             # run the wrapper and get the execution time
             compiler = subprocess.run(
                 [
-                    " ; ".join(
+                    " && ".join(
                         env_vars
                         + CompilingService.get_n_runs_script(
                             max_runs=max_runs,

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -397,7 +397,7 @@ class CompilingService:
         optims_list: List[TiramisuAction],
         max_runs: int = 0,
         max_mins_per_schedule: float | None = None,
-        delete_fiels: bool = True,
+        delete_files: bool = True,
         execution_timeout: float | None = None,
     ) -> List[float]:
         """Return the execution times of the program.
@@ -407,7 +407,7 @@ class CompilingService:
             optims_list (List[TiramisuAction]): The optimizations to apply
             max_runs (int, optional): The maximum number of runs. Defaults to 0.
             max_mins_per_schedule (float, optional): The maximum number of minutes per schedule. Defaults to None.
-            delete_fiels (bool, optional): If true, the generated files will be deleted. Defaults to True.
+            delete_files (bool, optional): If true, the generated files will be deleted. Defaults to True.
 
         Returns:
             List[float]: The execution times of the program
@@ -517,7 +517,7 @@ class CompilingService:
                         + CompilingService.get_n_runs_script(
                             max_runs=max_runs,
                             tiramisu_program=tiramisu_program,
-                            delete_files=delete_fiels,
+                            delete_files=delete_files,
                         )
                     )
                 ],

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -586,7 +586,7 @@ class CompilingService:
                         # if the command timed out
                         if compiler.returncode == 124:
                             logger.debug(
-                                f'Execution of wrapper timed-out. Completed {len(results)} out of {min_runs} min_runs and {len(compiler.stdout.split())} out of {nb_exec_left} extra runs. Collected measurements are [{' '.join(list(map(str, results)))}]+[{compiler.stdout}].'
+                                f"Execution of wrapper timed-out. Completed {len(results)} out of {min_runs} min_runs and {len(compiler.stdout.split())} out of {nb_exec_left} extra runs. Collected measurements are [{' '.join(list(map(str, results)))}]+[{compiler.stdout}]."
                             )
                         results += [float(x) for x in compiler.stdout.split()]
 

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -84,10 +84,10 @@ class Schedule:
         min_runs: int = 1,
         max_runs: int | None = None,
         time_budget: float | None = None,
-        delete_files: bool = True
+        delete_files: bool = True,
     ) -> List[float]:
         """
-        Applies the schedule to the Tiramisu program and performs a sequence 
+        Applies the schedule to the Tiramisu program and performs a sequence
         of execution time measurements.
 
         Parameters
@@ -97,18 +97,18 @@ class Schedule:
             The parameter guarantees that the execution time will be measured
             at least min_run times regardless of the set time budget.
         `time_budget` : float or None
-            Defines the duration (in milliseconds) allocated for execution 
-            time measurements. 
-            Once the time_budget is consumed, no more runs will be performed 
+            Defines the duration (in milliseconds) allocated for execution
+            time measurements.
+            Once the time_budget is consumed, no more runs will be performed
             and ongoing execution will be aborted.
             Measurements completed within the time_budget (if any) will be saved.
-            The min_runs first measurements are not abortable and will execute 
-            till completion even if time_budget is fully consumed. 
+            The min_runs first measurements are not abortable and will execute
+            till completion even if time_budget is fully consumed.
         `max_runs` : int or None
-            Defines the maximal number of times the schedule will be executed. 
-            This allows to stop taking measurements before time_budget is 
-            fully consumed. max_runs is only taken into consideration if 
-            time_budget is defined. If time_budget is defined and max_runs is 
+            Defines the maximal number of times the schedule will be executed.
+            This allows to stop taking measurements before time_budget is
+            fully consumed. max_runs is only taken into consideration if
+            time_budget is defined. If time_budget is defined and max_runs is
             None, max_run will be set to infinity.
         `delete_files` : bool
             Defines whether to delete the temporary generated files or not.

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -81,19 +81,37 @@ class Schedule:
 
     def execute(
         self,
-        nb_exec_times=1,
-        max_mins_per_schedule: float | None = None,
-        delete_files: bool = True,
-        execution_timeout: float | None = None,
+        min_runs: int = 1,
+        max_runs: int | None = None,
+        time_budget: float | None = None,
+        delete_files: bool = True
     ) -> List[float]:
         """
-        Applies the schedule to the Tiramisu program.
+        Applies the schedule to the Tiramisu program and performs a sequence 
+        of execution time measurements.
 
         Parameters
         ----------
-        `nb_exec_times` : int
-            The number of times the Tiramisu program will be executed after
-            applying the schedule.
+        `min_runs` : int
+            Defines the minimal number of times the schedule will be executed.
+            The parameter guarantees that the execution time will be measured
+            at least min_run times regardless of the set time budget.
+        `time_budget` : float or None
+            Defines the duration (in milliseconds) allocated for execution 
+            time measurements. 
+            Once the time_budget is consumed, no more runs will be performed 
+            and ongoing execution will be aborted.
+            Measurements completed within the time_budget (if any) will be saved.
+            The min_runs first measurements are not abortable and will execute 
+            till completion even if time_budget is fully consumed. 
+        `max_runs` : int or None
+            Defines the maximal number of times the schedule will be executed. 
+            This allows to stop taking measurements before time_budget is 
+            fully consumed. max_runs is only taken into consideration if 
+            time_budget is defined. If time_budget is defined and max_runs is 
+            None, max_run will be set to infinity.
+        `delete_files` : bool
+            Defines whether to delete the temporary generated files or not.
         Returns
         -------
         The execution time of the Tiramisu program after applying the schedule.
@@ -105,7 +123,7 @@ class Schedule:
             result = self.tiramisu_program.server.run(
                 operation="execution",
                 schedule=self,
-                nbr_executions=nb_exec_times,
+                nbr_executions=min_runs,
             )
             if result.legality is False:
                 raise Exception("Schedule is not legal")
@@ -121,10 +139,10 @@ class Schedule:
         return CompilingService.get_cpu_exec_times(
             self.tiramisu_program,
             self.optims_list,
-            nb_exec_times,
-            max_mins_per_schedule,
+            min_runs,
+            max_runs,
+            time_budget,
             delete_files,
-            execution_timeout,
         )
 
     def is_legal(self, with_ast: bool = False) -> bool:

--- a/tiralib/tiramisu/tiramisu_program.py
+++ b/tiralib/tiramisu/tiramisu_program.py
@@ -311,7 +311,7 @@ $buffers_init$
         auto end = std::chrono::high_resolution_clock::now();
 
         duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end-begin).count() / (double)1000000;
-        std::cout << duration << " ";
+        std::cout << duration << " " << std::flush;
 
     }
     std::cout << std::endl;
@@ -322,6 +322,8 @@ wrapper_h_template = """#include <tiramisu/utils.h>
 #include <cstdlib>
 #include <algorithm>
 #include <vector>
+#include <string>
+#include <limits>
 
 #define NB_THREAD_INIT 48
 struct args {
@@ -387,11 +389,17 @@ void declare_memory_usage(){
     setenv("MEM_SIZE", std::to_string((double)(256*192+320*256+320*192)*8/1024/1024).c_str(), true); // This value was set by the Code Generator
 }
 
-int get_nb_exec(){
-    if (std::getenv("NB_EXEC")!=NULL)
-        return std::stoi(std::getenv("NB_EXEC"));
-    else{
-        return 30;
+int get_nb_exec() {
+    const char* env_var = std::getenv("NB_EXEC");
+    if (env_var != nullptr) {
+        std::string env_value(env_var);
+        if (env_value == "inf") {
+            return std::numeric_limits<int>::max(); // Use maximum int value to represent +infinity
+        } else {
+            return std::stoi(env_value);
+        }
+    } else {
+        return 30; // Default value
     }
 }
 """  # noqa: E501


### PR DESCRIPTION
Hi,

I've just finished working on improving the time-budget handling for the `Schedule.execute` function as outlined in issue #36.

**What's Changed:**

The new mechanism introduces three new parameters `max_runs`, `min_runs`, and `time_budget`, and drops the existing `max_mins_per_schedule`, `execution_timeout`, and `nb_exec_times`.

- **min_runs:** This replaces the old `nb_exec_times`. It ensures getting a minimal number of complete executions regardless of any set time budget. This parameter can be set to zero for enforcing a strict time budget.

- **time_budget:** This is where users set the maximum duration (in milliseconds) for taking measurements. Once the budget's up, no more runs will happen, and any ongoing runs are aborted. Any data collected before hitting that budget will be saved and returned. The first `min_runs` are guaranteed to finish, regardless of the budget.

- **max_runs:** This limits the total number of runs, ensuring we can stop early if needed. This only applies if `time_budget` is set. If `max_runs` is not specified, it defaults to infinity, running until the `time_budget` is up.

These three parameters provide the flexibility needed to cover the use cases mentioned in #36 without loss of generality.


Thanks