### PR TITLE
fix: replace print with logger

### DIFF
--- a/tiralib/tiramisu/function_server.py
+++ b/tiralib/tiramisu/function_server.py
@@ -66,7 +66,7 @@ class ResultInterface:
             if match is None:
                 raise ValueError(f"Could not parse the result string: {decoded}")
             self.halide_ir = match.group(1)
-            print(self.halide_ir.replace("\\n", "\n"))
+            logger.info(self.halide_ir.replace("\\n", "\n"))
             decoded = match.group(2)
         result_dict = json.loads(decoded)
 
@@ -205,8 +205,7 @@ class FunctionServer:
         except subprocess.CalledProcessError as e:
             logger.error(f"Error while compiling server code: {e}")
             logger.error(e.output)
-            print(e.output)
-            print(e.stderr)
+            logger.error(e.stderr)
             raise e
 
     def run(
@@ -248,8 +247,7 @@ class FunctionServer:
         except subprocess.CalledProcessError as e:
             logger.error(f"Error while running server code: {e}")
             logger.error(e.output)
-            print(e.output)
-            print(e.stderr)
+            logger.error(e.stderr)
             raise e
         return ResultInterface(output)
 
@@ -278,8 +276,7 @@ class FunctionServer:
         except subprocess.CalledProcessError as e:
             logger.error(f"Error while running server code: {e}")
             logger.error(e.output)
-            print(e.output)
-            print(e.stderr)
+            logger.error(e.stderr)
             raise e
 
         return output.decode("utf-8").strip()


### PR DESCRIPTION
This pull request focuses on improving the logging mechanism in the `tiralib/tiramisu/function_server.py` file by replacing `print` statements with `logger` calls for better error handling and information logging.

Logging improvements:

* [`tiralib/tiramisu/function_server.py`](diffhunk://#diff-0a2ac3056cbee2a8b7085bb17dba9d4ba7cb3de5b870ae2c91c7629d1d70dbb9L69-R69): Replaced `print` statements with `logger.info` in the `__init__` method to log parsed `halide_ir` information.
* [`tiralib/tiramisu/function_server.py`](diffhunk://#diff-0a2ac3056cbee2a8b7085bb17dba9d4ba7cb3de5b870ae2c91c7629d1d70dbb9L208-R208): Replaced `print` statements with `logger.error` in the `_compile_server_code` method to log compilation errors and their outputs.
* [`tiralib/tiramisu/function_server.py`](diffhunk://#diff-0a2ac3056cbee2a8b7085bb17dba9d4ba7cb3de5b870ae2c91c7629d1d70dbb9L251-R250): Replaced `print` statements with `logger.error` in the `run` method to log runtime errors and their outputs.
* [`tiralib/tiramisu/function_server.py`](diffhunk://#diff-0a2ac3056cbee2a8b7085bb17dba9d4ba7cb3de5b870ae2c91c7629d1d70dbb9L281-R279): Replaced `print` statements with `logger.error` in the `get_annotations` method to log annotation retrieval errors and their outputs.