### PR TITLE
replace iterator name with iterator id everywhere

### DIFF
--- a/tests/tiramisu/test_tiramisu_tree.py
+++ b/tests/tiramisu/test_tiramisu_tree.py
@@ -31,28 +31,28 @@ def test_get_candidate_sections():
     candidate_sections = t_tree.get_candidate_sections()
 
     assert len(candidate_sections) == 1
-    root_id = t_tree.iterators["root"].id
+    root_id = ("comp01", 0)
     assert len(candidate_sections[root_id]) == 5
     assert candidate_sections[root_id][0] == [root_id]
-    assert candidate_sections[root_id][1] == [t_tree.iterators["i"].id]
+    assert candidate_sections[root_id][1] == [("comp01", 1)]
     assert candidate_sections[root_id][2] == [
-        t_tree.iterators["j"].id,
-        t_tree.iterators["k"].id,
+        ("comp03", 1),
+        ("comp03", 2),
     ]
-    assert candidate_sections[root_id][3] == [t_tree.iterators["l"].id]
-    assert candidate_sections[root_id][4] == [t_tree.iterators["m"].id]
+    assert candidate_sections[root_id][3] == [("comp03", 3)]
+    assert candidate_sections[root_id][4] == [("comp04", 3)]
 
 
 def test_get_candidate_computations():
     t_tree = test_utils.tree_test_sample()
 
-    assert t_tree.get_iterator_subtree_computations("root") == [
+    assert t_tree.get_iterator_subtree_computations(("comp01", 0)) == [
         "comp01",
         "comp03",
         "comp04",
     ]
-    assert t_tree.get_iterator_subtree_computations("i") == ["comp01"]
-    assert t_tree.get_iterator_subtree_computations("j") == [
+    assert t_tree.get_iterator_subtree_computations(("comp01", 1)) == ["comp01"]
+    assert t_tree.get_iterator_subtree_computations(("comp03", 1)) == [
         "comp03",
         "comp04",
     ]
@@ -61,15 +61,24 @@ def test_get_candidate_computations():
 def test_get_root_of_node():
     t_tree = test_utils.tree_test_sample()
 
-    assert t_tree.get_root_of_node("i") == "root"
-    assert t_tree.get_root_of_node("j") == "root"
-    assert t_tree.get_root_of_node("m") == "root"
+    assert t_tree.get_root_of_node(("comp01", 1)) == ("comp01", 0)
+    assert t_tree.get_root_of_node(("comp03", 1)) == ("comp01", 0)
+    assert t_tree.get_root_of_node(("comp04", 3)) == ("comp01", 0)
 
 
 def test_get_iterator_levels():
     t_tree = test_utils.tree_test_sample()
 
-    assert t_tree.get_iterator_levels(["root", "i", "j", "k", "l", "m"]) == [
+    assert t_tree.get_iterator_levels(
+        [
+            ("comp01", 0),
+            ("comp01", 1),
+            ("comp03", 1),
+            ("comp03", 2),
+            ("comp03", 3),
+            ("comp04", 3),
+        ]
+    ) == [
         0,
         1,
         1,
@@ -82,9 +91,9 @@ def test_get_iterator_levels():
 def test_get_iterator_of_computation():
     t_tree = test_utils.tree_test_sample()
 
-    assert t_tree.get_iterator_of_computation("comp01").name == "i"
-    assert t_tree.get_iterator_of_computation("comp03").name == "l"
-    assert t_tree.get_iterator_of_computation("comp04").name == "m"
+    assert t_tree.get_iterator_of_computation("comp01").name == ("comp01", 3)
+    assert t_tree.get_iterator_of_computation("comp03").name == ("comp03", 3)
+    assert t_tree.get_iterator_of_computation("comp04").name == ("comp04", 3)
 
-    assert t_tree.get_iterator_of_computation("comp01", level=0).name == "root"
-    assert t_tree.get_iterator_of_computation("comp03", level=1).name == "j"
+    assert t_tree.get_iterator_of_computation("comp01", level=0).name == ("comp01", 0)
+    assert t_tree.get_iterator_of_computation("comp03", level=1).name == ("comp03", 1)

--- a/tests/tiramisu/test_tiramisu_tree.py
+++ b/tests/tiramisu/test_tiramisu_tree.py
@@ -91,9 +91,9 @@ def test_get_iterator_levels():
 def test_get_iterator_of_computation():
     t_tree = test_utils.tree_test_sample()
 
-    assert t_tree.get_iterator_of_computation("comp01").name == ("comp01", 3)
-    assert t_tree.get_iterator_of_computation("comp03").name == ("comp03", 3)
-    assert t_tree.get_iterator_of_computation("comp04").name == ("comp04", 3)
+    assert t_tree.get_iterator_of_computation("comp01").name == "i"
+    assert t_tree.get_iterator_of_computation("comp03").name == "l"
+    assert t_tree.get_iterator_of_computation("comp04").name == "m"
 
-    assert t_tree.get_iterator_of_computation("comp01", level=0).name == ("comp01", 0)
-    assert t_tree.get_iterator_of_computation("comp03", level=1).name == ("comp03", 1)
+    assert t_tree.get_iterator_of_computation("comp01", level=0).name == "root"
+    assert t_tree.get_iterator_of_computation("comp03", level=1).name == "j"

--- a/tests/tiramisu/tiramisu_actions/test_distribution.py
+++ b/tests/tiramisu/tiramisu_actions/test_distribution.py
@@ -66,8 +66,8 @@ def test_get_candidates():
     sample = test_utils.gramschmidt_sample()
     candidates = Distribution.get_candidates(sample.tree)
     assert candidates == [
-        sample.tree.iterators["c1"].id,
-        sample.tree.iterators["c3_2"].id,
+        ("nrm_init", 0),
+        ("R_up_init", 1),
     ]
 
 

--- a/tests/tiramisu/tiramisu_actions/test_fusion.py
+++ b/tests/tiramisu/tiramisu_actions/test_fusion.py
@@ -34,8 +34,8 @@ def test_get_candidates():
     sample = test_utils.fusion_sample()
     candidates = Fusion.get_candidates(sample.tree)
     assert candidates == [
-        (sample.tree.iterators["i"].id, sample.tree.iterators["j"].id),
-        (sample.tree.iterators["l"].id, sample.tree.iterators["m"].id),
+        (("comp01", 1), ("comp03", 1)),
+        (("comp03", 3), ("comp04", 3)),
     ]
 
 

--- a/tests/tiramisu/tiramisu_actions/test_interchange.py
+++ b/tests/tiramisu/tiramisu_actions/test_interchange.py
@@ -39,10 +39,10 @@ def test_get_candidates():
     sample = interchange_example()
     candidates = Interchange.get_candidates(sample.tree)
     assert candidates == {
-        sample.tree.iterators["i0"].id: [
-            (sample.tree.iterators["i0"].id, sample.tree.iterators["i1"].id),
-            (sample.tree.iterators["i0"].id, sample.tree.iterators["i2"].id),
-            (sample.tree.iterators["i1"].id, sample.tree.iterators["i2"].id),
+        ("comp00", 0): [
+            (("comp00", 0), ("comp00", 1)),
+            (("comp00", 0), ("comp00", 2)),
+            (("comp00", 1), ("comp00", 2)),
         ]
     }
 

--- a/tests/tiramisu/tiramisu_actions/test_parallelization.py
+++ b/tests/tiramisu/tiramisu_actions/test_parallelization.py
@@ -38,10 +38,10 @@ def test_get_candidates():
     sample = test_utils.benchmark_program_test_sample()
     candidates = Parallelization.get_candidates(sample.tree)
     assert candidates == {
-        sample.tree.iterators["c1"].id: [
-            [sample.tree.iterators["c1"].id],
-            [sample.tree.iterators["c3"].id],
-            [sample.tree.iterators["c5"].id],
+        ("comp02", 0): [
+            [("comp02", 0)],
+            [("comp02", 1)],
+            [("comp02", 2)],
         ]
     }
 

--- a/tests/tiramisu/tiramisu_actions/test_reversal.py
+++ b/tests/tiramisu/tiramisu_actions/test_reversal.py
@@ -37,8 +37,8 @@ def test_get_candidates():
     sample = test_utils.reversal_sample()
     candidates = Reversal.get_candidates(sample.tree)
     assert candidates == {
-        sample.tree.iterators["i0"].id: [
-            sample.tree.iterators["i0"].id,
-            sample.tree.iterators["i1"].id,
+        ("comp00", 0): [
+            ("comp00", 0),
+            ("comp00", 1),
         ]
     }

--- a/tests/tiramisu/tiramisu_actions/test_skewing.py
+++ b/tests/tiramisu/tiramisu_actions/test_skewing.py
@@ -40,27 +40,25 @@ def test_get_candidates():
     sample = test_utils.skewing_example()
     candidates = Skewing.get_candidates(sample.tree)
     assert candidates == {
-        sample.tree.iterators["i0"].id: [
-            (sample.tree.iterators["i0"].id, sample.tree.iterators["i1"].id),
-            (sample.tree.iterators["i1"].id, sample.tree.iterators["i2"].id),
+        ("comp00", 0): [
+            (("comp00", 0), ("comp00", 1)),
+            (("comp00", 1), ("comp00", 2)),
         ]
     }
 
     tree = test_utils.tree_test_sample()
     candidates = Skewing.get_candidates(tree)
-    assert candidates == {
-        tree.iterators["root"].id: [(tree.iterators["j"].id, tree.iterators["k"].id)]
-    }
+    assert candidates == {("comp01", 0): [(("comp03", 1), ("comp03", 2))]}
 
 
 def test_get_factors():
     BaseConfig.init()
     sample = test_utils.skewing_example()
-    loop_levels = sample.tree.get_iterator_levels(["i0", "i1"])
+    loop_levels = sample.tree.get_iterator_levels([("comp00", 0), ("comp00", 1)])
     schedule = Schedule(sample)
     factors = Skewing.get_factors(
         schedule=schedule,
         loop_levels=loop_levels,
-        comps_skewed_loops=sample.tree.get_iterator_subtree_computations("i0"),
+        comps_skewed_loops=sample.tree.get_iterator_subtree_computations(("comp00", 0)),
     )
     assert factors == (1, 1)

--- a/tests/tiramisu/tiramisu_actions/test_tiling_2d.py
+++ b/tests/tiramisu/tiramisu_actions/test_tiling_2d.py
@@ -40,17 +40,11 @@ def test_get_candidates():
     BaseConfig.init()
     sample = test_utils.tiling_2d_sample()
     candidates = Tiling2D.get_candidates(sample.tree)
-    assert candidates == {
-        sample.tree.iterators["i0"].id: [
-            (sample.tree.iterators["i0"].id, sample.tree.iterators["i1"].id)
-        ]
-    }
+    assert candidates == {("comp00", 0): [(("comp00", 0), ("comp00", 1))]}
 
     tree = test_utils.tree_test_sample()
     candidates = Tiling2D.get_candidates(tree)
-    assert candidates == {
-        tree.iterators["root"].id: [(tree.iterators["j"].id, tree.iterators["k"].id)]
-    }
+    assert candidates == {("comp01", 0): [(("comp03", 1), ("comp03", 2))]}
 
 
 def test_fusion_levels():

--- a/tests/tiramisu/tiramisu_actions/test_tiling_3d.py
+++ b/tests/tiramisu/tiramisu_actions/test_tiling_3d.py
@@ -80,11 +80,11 @@ def test_get_candidates():
     sample = test_utils.tiling_3d_sample()
     candidates = Tiling3D.get_candidates(sample.tree)
     assert candidates == {
-        sample.tree.iterators["i0"].id: [
+        ("comp00", 0): [
             (
-                sample.tree.iterators["i0"].id,
-                sample.tree.iterators["i1"].id,
-                sample.tree.iterators["i2"].id,
+                ("comp00", 0),
+                ("comp00", 1),
+                ("comp00", 2),
             )
         ]
     }
@@ -92,16 +92,16 @@ def test_get_candidates():
     tree = test_utils.tiling_3d_tree_sample()
     candidates = Tiling3D.get_candidates(tree)
     assert candidates == {
-        tree.iterators["root"].id: [
+        ("comp03", 0): [
             (
-                tree.iterators["root"].id,
-                tree.iterators["j"].id,
-                tree.iterators["k"].id,
+                ("comp03", 0),
+                ("comp03", 1),
+                ("comp03", 2),
             ),
             (
-                tree.iterators["j"].id,
-                tree.iterators["k"].id,
-                tree.iterators["l"].id,
+                ("comp03", 1),
+                ("comp03", 2),
+                ("comp03", 3),
             ),
         ]
     }

--- a/tests/tiramisu/tiramisu_actions/test_tiling_general.py
+++ b/tests/tiramisu/tiramisu_actions/test_tiling_general.py
@@ -29,12 +29,11 @@ def test_initialize_action_for_tree():
         ("A_out", 2),
     ]
     assert tiling_general.tile_sizes_dict == {
-        "c3_2": 10,
-        "c5": 10,
-        "c5_1": 10,
+        ("R_up_init", 1): 10,
+        ("R_up", 2): 10,
+        ("A_out", 2): 10,
     }
     assert tiling_general.comps == ["R_up_init", "R_up", "A_out"]
-    assert tiling_general.tiled_iterator_names == ["c3_2", "c5", "c5_1"]
 
 
 def test_set_string_representations():
@@ -66,19 +65,19 @@ def test_get_candidates():
     sample = test_utils.gramschmidt_sample()
     candidates = TilingGeneral.get_candidates(sample.tree)
     assert candidates == {
-        sample.tree.iterators["c1"].id: [
+        ("nrm_init", 0): [
             [
-                sample.tree.iterators["c1"].id,
-                sample.tree.iterators["c3"].id,
-                sample.tree.iterators["c3_1"].id,
-                sample.tree.iterators["c3_2"].id,
-                sample.tree.iterators["c5"].id,
-                sample.tree.iterators["c5_1"].id,
+                ("nrm_init", 0),
+                ("nrm_comp", 1),
+                ("Q_out", 1),
+                ("R_up_init", 1),
+                ("R_up", 2),
+                ("A_out", 2),
             ],
             [
-                sample.tree.iterators["c3_2"].id,
-                sample.tree.iterators["c5"].id,
-                sample.tree.iterators["c5_1"].id,
+                ("R_up_init", 1),
+                ("R_up", 2),
+                ("A_out", 2),
             ],
         ]
     }
@@ -86,14 +85,14 @@ def test_get_candidates():
     tree = test_utils.tree_test_sample()
     candidates = TilingGeneral.get_candidates(tree)
     assert candidates == {
-        tree.iterators["root"].id: [
+        ("comp01", 0): [
             [
-                tree.iterators["root"].id,
-                tree.iterators["i"].id,
-                tree.iterators["j"].id,
-                tree.iterators["k"].id,
-                tree.iterators["l"].id,
-                tree.iterators["m"].id,
+                ("comp01", 0),
+                ("comp01", 1),
+                ("comp03", 1),
+                ("comp03", 2),
+                ("comp03", 3),
+                ("comp04", 3),
             ]
         ]
     }
@@ -101,22 +100,22 @@ def test_get_candidates():
     t_tree = test_utils.tree_test_sample_imperfect_loops()
     candidates = TilingGeneral.get_candidates(t_tree)
     assert candidates == {
-        t_tree.iterators["root"].id: [
+        ("comp01", 0): [
             [
-                t_tree.iterators["root"].id,
-                t_tree.iterators["i"].id,
-                t_tree.iterators["i_1"].id,
-                t_tree.iterators["j"].id,
-                t_tree.iterators["j_1"].id,
-                t_tree.iterators["k"].id,
+                ("comp01", 0),
+                ("comp01", 1),
+                ("comp04", 1),
+                ("comp02", 2),
+                ("comp05", 2),
+                ("comp03", 3),
             ],
-            [t_tree.iterators["i"].id, t_tree.iterators["j"].id],
-            [t_tree.iterators["j"].id, t_tree.iterators["k"].id],
+            [("comp01", 1), ("comp02", 2)],
+            [("comp02", 2), ("comp03", 3)],
             [
-                t_tree.iterators["i"].id,
-                t_tree.iterators["j"].id,
-                t_tree.iterators["k"].id,
+                ("comp01", 1),
+                ("comp02", 2),
+                ("comp03", 3),
             ],
-            [t_tree.iterators["i_1"].id, t_tree.iterators["j_1"].id],
+            [("comp04", 1), ("comp05", 2)],
         ]
     }

--- a/tests/tiramisu/tiramisu_actions/test_unrolling.py
+++ b/tests/tiramisu/tiramisu_actions/test_unrolling.py
@@ -43,12 +43,12 @@ def test_get_candidates():
     BaseConfig.init()
     sample = test_utils.unrolling_sample()
     candidates = Unrolling.get_candidates(sample.tree)
-    assert candidates == [sample.tree.iterators["i1"].id]
+    assert candidates == [("comp00", 1)]
 
     tree = test_utils.tree_test_sample()
     candidates = Unrolling.get_candidates(tree)
     assert candidates == [
-        tree.iterators["i"].id,
-        tree.iterators["l"].id,
-        tree.iterators["m"].id,
+        ("comp01", 1),
+        ("comp03", 3),
+        ("comp04", 3),
     ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,56 +16,56 @@ def load_test_data() -> Tuple[dict, dict]:
 
 def tree_test_sample():
     tiramisu_tree = TiramisuTree()
-    tiramisu_tree.add_root("root")
+    tiramisu_tree.add_root(("comp01", 0))
     tiramisu_tree.iterators = {
-        "root": IteratorNode(
+        ("comp01", 0): IteratorNode(
             name="root",
             parent_iterator=None,
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["i", "j"],
+            child_iterators=[("comp01", 1), ("comp03", 1)],
             computations_list=[],
             level=0,
         ),
-        "i": IteratorNode(
+        ("comp01", 1): IteratorNode(
             name="i",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=256,
             child_iterators=[],
             computations_list=["comp01"],
             level=1,
         ),
-        "j": IteratorNode(
+        ("comp03", 1): IteratorNode(
             name="j",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["k"],
+            child_iterators=[("comp03", 2)],
             computations_list=[],
             level=1,
         ),
-        "k": IteratorNode(
+        ("comp03", 2): IteratorNode(
             name="k",
-            parent_iterator="j",
+            parent_iterator=("comp03", 1),
             lower_bound=0,
             upper_bound=10,
-            child_iterators=["l", "m"],
+            child_iterators=[("comp03", 3), ("comp04", 3)],
             computations_list=[],
             level=2,
         ),
-        "l": IteratorNode(
+        ("comp03", 3): IteratorNode(
             name="l",
-            parent_iterator="k",
+            parent_iterator=("comp03", 2),
             lower_bound=0,
             upper_bound=256,
             child_iterators=[],
             computations_list=["comp03"],
             level=3,
         ),
-        "m": IteratorNode(
+        ("comp04", 3): IteratorNode(
             name="m",
-            parent_iterator="k",
+            parent_iterator=("comp03", 2),
             lower_bound=0,
             upper_bound=256,
             child_iterators=[],
@@ -90,56 +90,56 @@ def tree_test_sample():
 
 def tree_test_sample_2():
     tiramisu_tree = TiramisuTree()
-    tiramisu_tree.add_root("root")
+    tiramisu_tree.add_root(("comp01", 0))
     tiramisu_tree.iterators = {
-        "root": IteratorNode(
+        ("comp01", 0): IteratorNode(
             name="root",
             parent_iterator=None,
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["i", "j"],
+            child_iterators=[("comp01", 1), ("comp05", 1)],
             computations_list=[],
             level=0,
         ),
-        "i": IteratorNode(
+        ("comp01", 1): IteratorNode(
             name="i",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=256,
             child_iterators=[],
             computations_list=["comp01"],
             level=1,
         ),
-        "j": IteratorNode(
+        ("comp05", 1): IteratorNode(
             name="j",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["k"],
+            child_iterators=[("comp03", 2)],
             computations_list=["comp05", "comp06", "comp07"],
             level=1,
         ),
-        "k": IteratorNode(
+        ("comp03", 2): IteratorNode(
             name="k",
-            parent_iterator="j",
+            parent_iterator=("comp05", 1),
             lower_bound=0,
             upper_bound=10,
-            child_iterators=["l", "m"],
+            child_iterators=[("comp03", 3), ("comp04", 3)],
             computations_list=[],
             level=2,
         ),
-        "l": IteratorNode(
+        ("comp03", 3): IteratorNode(
             name="l",
-            parent_iterator="k",
+            parent_iterator=("comp03", 2),
             lower_bound=0,
             upper_bound=256,
             child_iterators=[],
             computations_list=["comp03"],
             level=3,
         ),
-        "m": IteratorNode(
+        ("comp04", 3): IteratorNode(
             name="m",
-            parent_iterator="k",
+            parent_iterator=("comp03", 2),
             lower_bound=0,
             upper_bound=256,
             child_iterators=[],
@@ -159,66 +159,67 @@ def tree_test_sample_2():
     tiramisu_tree.computations_absolute_order = {
         "comp01": 1,
         "comp05": 2,
-        "comp03": 5,
-        "comp04": 6,
         "comp06": 3,
         "comp07": 4,
+        "comp03": 5,
+        "comp04": 6,
     }
+    tiramisu_tree.set_iterator_ids()
     return tiramisu_tree
 
 
 def tree_test_sample_3():
     tiramisu_tree = TiramisuTree()
-    tiramisu_tree.add_root("root")
+    tiramisu_tree.add_root(("comp01", 0))
     tiramisu_tree.iterators = {
-        "root": IteratorNode(
+        ("comp01", 0): IteratorNode(
             name="root",
             parent_iterator=None,
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["i", "j"],
+            child_iterators=[("comp01", 1), ("comp05", 1)],
             computations_list=[],
             level=0,
         ),
-        "i": IteratorNode(
+        ("comp01", 1): IteratorNode(
             name="i",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=256,
             child_iterators=[],
             computations_list=["comp01"],
             level=1,
         ),
-        "j": IteratorNode(
+        ("comp05", 1): IteratorNode(
             name="j",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["k"],
+            child_iterators=[("comp03", 2)],
             computations_list=["comp05", "comp06", "comp07"],
             level=1,
         ),
-        "k": IteratorNode(
+        ("comp03", 2): IteratorNode(
             name="k",
-            parent_iterator="j",
+            parent_iterator=("comp05", 1),
             lower_bound=0,
             upper_bound=10,
-            child_iterators=["l"],
+            child_iterators=[("comp03", 3)],
             computations_list=[],
             level=2,
         ),
-        "l": IteratorNode(
+        ("comp03", 3): IteratorNode(
             name="l",
-            parent_iterator="k",
+            parent_iterator=("comp03", 2),
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["m"],
+            child_iterators=[("comp03", 4)],
             computations_list=[],
             level=3,
         ),
-        "m": IteratorNode(
+        ("comp03", 4): IteratorNode(
             name="m",
-            parent_iterator="l",
+            parent_iterator=("comp03", 3),
             lower_bound=0,
             upper_bound=256,
             child_iterators=[],
@@ -243,61 +244,62 @@ def tree_test_sample_3():
         "comp06": 3,
         "comp07": 4,
     }
+    tiramisu_tree.set_iterator_ids()
     return tiramisu_tree
 
 
 def tree_test_sample_imperfect_loops():
     tiramisu_tree = TiramisuTree()
-    tiramisu_tree.add_root("root")
+    tiramisu_tree.add_root(("comp01", 0))
     tiramisu_tree.iterators = {
-        "root": IteratorNode(
+        ("comp01", 0): IteratorNode(
             name="root",
             parent_iterator=None,
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["i", "i_1"],
+            child_iterators=[("comp01", 1), ("comp04", 1)],
             computations_list=[],
             level=0,
         ),
-        "i": IteratorNode(
+        ("comp01", 1): IteratorNode(
             name="i",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["j"],
+            child_iterators=[("comp02", 2)],
             computations_list=["comp01"],
             level=1,
         ),
-        "j": IteratorNode(
+        ("comp02", 2): IteratorNode(
             name="j",
-            parent_iterator="i",
+            parent_iterator=("comp01", 1),
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["k"],
+            child_iterators=[("comp03", 3)],
             computations_list=["comp02"],
-            level=1,
+            level=2,
         ),
-        "k": IteratorNode(
+        ("comp03", 3): IteratorNode(
             name="k",
-            parent_iterator="j",
+            parent_iterator=("comp02", 1),
             lower_bound=0,
             upper_bound=10,
             child_iterators=[],
             computations_list=["comp03"],
-            level=2,
+            level=3,
         ),
-        "i_1": IteratorNode(
+        ("comp04", 1): IteratorNode(
             name="i_1",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=256,
-            child_iterators=["j_1"],
+            child_iterators=[("comp05", 2)],
             computations_list=["comp04"],
             level=1,
         ),
-        "j_1": IteratorNode(
+        ("comp05", 2): IteratorNode(
             name="j_1",
-            parent_iterator="i_1",
+            parent_iterator=("comp04", 1),
             lower_bound=0,
             upper_bound=256,
             child_iterators=[],
@@ -438,38 +440,38 @@ def tiling_3d_sample() -> TiramisuProgram:
 
 def tiling_3d_tree_sample() -> TiramisuTree:
     tiramisu_tree = TiramisuTree()
-    tiramisu_tree.add_root("root")
+    tiramisu_tree.add_root(("comp03", 0))
     tiramisu_tree.iterators = {
-        "root": IteratorNode(
+        ("comp03", 0): IteratorNode(
             name="root",
             parent_iterator=None,
             lower_bound=0,
             upper_bound=10,
-            child_iterators=["j"],
+            child_iterators=[("comp03", 1)],
             computations_list=[],
             level=0,
         ),
-        "j": IteratorNode(
+        ("comp03", 1): IteratorNode(
             name="j",
-            parent_iterator="root",
+            parent_iterator=("comp03", 0),
             lower_bound=0,
             upper_bound=10,
-            child_iterators=["k"],
+            child_iterators=[("comp03", 2)],
             computations_list=[],
             level=1,
         ),
-        "k": IteratorNode(
+        ("comp03", 2): IteratorNode(
             name="k",
-            parent_iterator="j",
+            parent_iterator=("comp03", 1),
             lower_bound=0,
             upper_bound=10,
-            child_iterators=["l"],
+            child_iterators=[("comp03", 3)],
             computations_list=[],
             level=2,
         ),
-        "l": IteratorNode(
+        ("comp03", 3): IteratorNode(
             name="l",
-            parent_iterator="k",
+            parent_iterator=("comp03", 2),
             lower_bound=0,
             upper_bound=10,
             child_iterators=[],
@@ -492,56 +494,56 @@ def fusion_sample():
     tiramisu_prog = TiramisuProgram()
 
     tiramisu_tree = TiramisuTree()
-    tiramisu_tree.add_root("root")
+    tiramisu_tree.add_root(("comp01", 0))
     tiramisu_tree.iterators = {
-        "root": IteratorNode(
+        ("comp01", 0): IteratorNode(
             name="root",
             parent_iterator=None,
             lower_bound=0,
             upper_bound=10,
-            child_iterators=["i", "j"],
+            child_iterators=[("comp01", 1), ("comp03", 1)],
             computations_list=[],
             level=0,
         ),
-        "i": IteratorNode(
+        ("comp01", 1): IteratorNode(
             name="i",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=10,
             child_iterators=[],
             computations_list=["comp01"],
             level=1,
         ),
-        "j": IteratorNode(
+        ("comp03", 1): IteratorNode(
             name="j",
-            parent_iterator="root",
+            parent_iterator=("comp01", 0),
             lower_bound=0,
             upper_bound=10,
-            child_iterators=["k"],
+            child_iterators=[("comp03", 2)],
             computations_list=[],
             level=1,
         ),
-        "k": IteratorNode(
+        ("comp03", 2): IteratorNode(
             name="k",
-            parent_iterator="j",
+            parent_iterator=("comp03", 1),
             lower_bound=0,
             upper_bound=10,
-            child_iterators=["l", "m"],
+            child_iterators=[("comp03", 3), ("comp04", 3)],
             computations_list=[],
             level=2,
         ),
-        "l": IteratorNode(
+        ("comp03", 3): IteratorNode(
             name="l",
-            parent_iterator="k",
+            parent_iterator=("comp03", 2),
             lower_bound=0,
             upper_bound=10,
             child_iterators=[],
             computations_list=["comp03"],
             level=3,
         ),
-        "m": IteratorNode(
+        ("comp04", 3): IteratorNode(
             name="m",
-            parent_iterator="k",
+            parent_iterator=("comp03", 2),
             lower_bound=0,
             upper_bound=10,
             child_iterators=[],
@@ -560,7 +562,7 @@ def fusion_sample():
         "comp03": 2,
         "comp04": 3,
     }
-
+    tiramisu_tree.set_iterator_ids()
     tiramisu_prog.tree = tiramisu_tree
     return tiramisu_prog
 

--- a/tiralib/tiramisu/function_server.py
+++ b/tiralib/tiramisu/function_server.py
@@ -66,7 +66,7 @@ class ResultInterface:
             if match is None:
                 raise ValueError(f"Could not parse the result string: {decoded}")
             self.halide_ir = match.group(1)
-            logger.info(self.halide_ir.replace("\\n", "\n"))
+            logger.debug(self.halide_ir.replace("\\n", "\n"))
             decoded = match.group(2)
         result_dict = json.loads(decoded)
 

--- a/tiralib/tiramisu/tiramisu_actions/fusion.py
+++ b/tiralib/tiramisu/tiramisu_actions/fusion.py
@@ -42,12 +42,12 @@ class Fusion(TiramisuAction):
         self.iterators: List[IteratorNode] = []
         self.itertors_computations: List[List[str]] = []
         for iterator_id in self.params:
-            iterator = tiramisu_tree.get_iterator_of_computation(
-                iterator_id[0], iterator_id[1]
-            )
+            if iterator_id not in tiramisu_tree.iterators:
+                iterator_id = self.tree.get_iterator_of_computation(*iterator_id).id
+            iterator = tiramisu_tree.iterators[iterator_id]
             self.iterators.append(iterator)
             iterator_computations = tiramisu_tree.get_iterator_subtree_computations(
-                iterator.name
+                iterator.id
             )
             self.itertors_computations.append(iterator_computations)
             self.comps.extend(iterator_computations)
@@ -135,8 +135,8 @@ perform_full_dependency_analysis();
             for root in program_tree.roots:
                 iterators_dict[root] = []
             for iterator in iterators:
-                iterators_dict[program_tree.get_root_of_node(iterator.name)].append(
-                    iterator.name
+                iterators_dict[program_tree.get_root_of_node(iterator.id)].append(
+                    iterator.id
                 )
             for root in iterators_dict:
                 candidates.extend(
@@ -168,7 +168,7 @@ perform_full_dependency_analysis();
             fused_computations[0], self.main_fusion_level
         )
         comps_in_fused_iterator = tiramisu_tree.get_iterator_subtree_computations(
-            fused_in_iterator.name
+            fused_in_iterator.id
         )
         max_order = max(
             [
@@ -207,7 +207,7 @@ perform_full_dependency_analysis();
             fusion_level: int | None = None
 
             # get the shared iterator level
-            while iter_comp_1.name != iter_comp_2.name:
+            while iter_comp_1.id != iter_comp_2.id:
                 if iter_comp_1.level > iter_comp_2.level:
                     # if parent is None
                     # then the iterators don't have a common parent

--- a/tiralib/tiramisu/tiramisu_actions/interchange.py
+++ b/tiralib/tiramisu/tiramisu_actions/interchange.py
@@ -26,6 +26,7 @@ class Interchange(TiramisuAction):
 
         self.params = params
         self.comps = comps
+        self.iterators: list[IteratorIdentifier] = [params[0], params[1]]
 
         super().__init__(
             type=TiramisuActionType.INTERCHANGE, params=params, comps=comps
@@ -46,7 +47,7 @@ class Interchange(TiramisuAction):
             )
 
             self.comps = self.tree.get_iterator_subtree_computations(
-                innermost_iterator.name
+                innermost_iterator.id
             )
 
         self.set_string_representations(self.tree)

--- a/tiralib/tiramisu/tiramisu_actions/parallelization.py
+++ b/tiralib/tiramisu/tiramisu_actions/parallelization.py
@@ -38,12 +38,15 @@ class Parallelization(TiramisuAction):
         # we save a copy of the tree to be able to restore it later
         self.tree = copy.deepcopy(tiramisu_tree)
 
+        # user passed a different iteratorId than the main one
+        if self.iterator_id not in tiramisu_tree.iterators:
+            self.iterator_id = self.tree.get_iterator_of_computation(
+                *self.iterator_id
+            ).id
         if self.comps is None:
-            iterator = tiramisu_tree.get_iterator_of_computation(
-                self.iterator_id[0], self.iterator_id[1]
-            )
+            iterator = tiramisu_tree.iterators[self.iterator_id]
 
-            self.comps = tiramisu_tree.get_iterator_subtree_computations(iterator.name)
+            self.comps = tiramisu_tree.get_iterator_subtree_computations(iterator.id)
             # order the computations by their absolute order
             self.comps.sort(
                 key=lambda comp: tiramisu_tree.computations_absolute_order[comp]

--- a/tiralib/tiramisu/tiramisu_actions/reversal.py
+++ b/tiralib/tiramisu/tiramisu_actions/reversal.py
@@ -32,12 +32,16 @@ class Reversal(TiramisuAction):
         # clone the tree to be able to restore it later
         self.tree = copy.deepcopy(tiramisu_tree)
 
-        if self.comps is None:
-            iterator = tiramisu_tree.get_iterator_of_computation(
-                self.iterator_id[0], self.iterator_id[1]
-            )
+        # user passed a different iteratorId than the main one
+        if self.iterator_id not in tiramisu_tree.iterators:
+            self.iterator_id = self.tree.get_iterator_of_computation(
+                *self.iterator_id
+            ).id
 
-            self.comps = tiramisu_tree.get_iterator_subtree_computations(iterator.name)
+        if self.comps is None:
+            iterator = tiramisu_tree.iterators[self.iterator_id]
+
+            self.comps = tiramisu_tree.get_iterator_subtree_computations(iterator.id)
             # order the computations by their absolute order
             self.comps.sort(
                 key=lambda comp: tiramisu_tree.computations_absolute_order[comp]

--- a/tiralib/tiramisu/tiramisu_actions/skewing.py
+++ b/tiralib/tiramisu/tiramisu_actions/skewing.py
@@ -35,8 +35,8 @@ class Skewing(TiramisuAction):
         self.params = params
         self.comps = comps
 
-        self.iterators = params[:2]
-        self.factors = params[2:]
+        self.iterators: list[IteratorIdentifier] = params[:2]
+        self.factors: list[int] = params[2:]
 
         super().__init__(
             type=TiramisuActionType.SKEWING,
@@ -47,17 +47,20 @@ class Skewing(TiramisuAction):
     def initialize_action_for_tree(self, tiramisu_tree: TiramisuTree):
         # clone the tree to be able to restore it later
         self.tree = copy.deepcopy(tiramisu_tree)
+        for idx, iterator in enumerate(self.iterators):
+            if iterator not in tiramisu_tree.iterators:
+                self.iterators[idx] = self.tree.get_iterator_of_computation(
+                    *iterator
+                ).id
 
         if self.comps is None:
             outermost_iterator_id = self.iterators[0]
-            outermost_iterator = self.tree.get_iterator_of_computation(
-                *outermost_iterator_id
-            )
+            outermost_iterator = self.tree.iterators[outermost_iterator_id]
 
             # get the computations of the outermost iterator subtree
             # (includes the innermost iterator)
             self.comps = self.tree.get_iterator_subtree_computations(
-                outermost_iterator.name
+                outermost_iterator.id
             )
             # sort the computations according to the absolute order
             self.comps.sort(

--- a/tiralib/tiramisu/tiramisu_actions/tiling_2d.py
+++ b/tiralib/tiramisu/tiramisu_actions/tiling_2d.py
@@ -36,8 +36,8 @@ class Tiling2D(TiramisuAction):
         self.params = params
         self.comps = comps
 
-        self.iterators = [params[0], params[1]]
-        self.tile_sizes = [params[2], params[3]]
+        self.iterators: list[IteratorIdentifier] = [params[0], params[1]]
+        self.tile_sizes: list[int] = [params[2], params[3]]
 
         super().__init__(
             type=TiramisuActionType.TILING_2D,
@@ -48,6 +48,11 @@ class Tiling2D(TiramisuAction):
     def initialize_action_for_tree(self, tiramisu_tree: TiramisuTree):
         # clone the tree to be able to restore it later
         self.tree = copy.deepcopy(tiramisu_tree)
+        for idx, iterator in enumerate(self.iterators):
+            if iterator not in tiramisu_tree.iterators:
+                self.iterators[idx] = self.tree.get_iterator_of_computation(
+                    *iterator
+                ).id
 
         if self.comps is None:
             outermost_iterator_id = (
@@ -56,14 +61,12 @@ class Tiling2D(TiramisuAction):
                 else self.iterators[1]
             )
 
-            outermost_iterator = self.tree.get_iterator_of_computation(
-                *outermost_iterator_id
-            )
+            outermost_iterator = self.tree.iterators[outermost_iterator_id]
 
             # get the computations of the outermost
             # iterator subtree (includes the innermost iterator)
             self.comps = self.tree.get_iterator_subtree_computations(
-                outermost_iterator.name
+                outermost_iterator.id
             )
             # sort the computations according to the absolute order
             self.comps.sort(

--- a/tiralib/tiramisu/tiramisu_actions/tiling_3d.py
+++ b/tiralib/tiramisu/tiramisu_actions/tiling_3d.py
@@ -55,6 +55,11 @@ class Tiling3D(TiramisuAction):
     def initialize_action_for_tree(self, tiramisu_tree: TiramisuTree):
         # clone the tree to be able to restore it later
         self.tree = copy.deepcopy(tiramisu_tree)
+        for idx, iterator in enumerate(self.iterators):
+            if iterator not in tiramisu_tree.iterators:
+                self.iterators[idx] = self.tree.get_iterator_of_computation(
+                    *iterator
+                ).id
 
         if self.comps is None:
             outermost_iterator_id = self.iterators[0]
@@ -62,13 +67,11 @@ class Tiling3D(TiramisuAction):
                 if iterator[1] < outermost_iterator_id[1]:
                     outermost_iterator_id = iterator
 
-            outermost_iterator = self.tree.get_iterator_of_computation(
-                *outermost_iterator_id
-            )
+            outermost_iterator = self.tree.iterators[outermost_iterator_id]
             # get the computations of the outermost iterator to tile
             # which include the computations of the other iterators
             self.comps = self.tree.get_iterator_subtree_computations(
-                outermost_iterator.name
+                outermost_iterator.id
             )
 
             # sort the computations according to the absolute order

--- a/tiralib/tiramisu/tiramisu_actions/unrolling.py
+++ b/tiralib/tiramisu/tiramisu_actions/unrolling.py
@@ -39,12 +39,16 @@ class Unrolling(TiramisuAction):
     def initialize_action_for_tree(self, tiramisu_tree: TiramisuTree):
         # clone the tree to be able to restore it later
         self.tree = copy.deepcopy(tiramisu_tree)
+        if self.iterator_id not in tiramisu_tree.iterators:
+            self.iterator_id = self.tree.get_iterator_of_computation(
+                *self.iterator_id
+            ).id
 
         if self.comps is None:
-            iterator = tiramisu_tree.get_iterator_of_computation(*self.iterator_id)
+            iterator = tiramisu_tree.iterators[self.iterator_id]
 
             # Get the computations that are in the loop to be unrolled
-            self.comps = tiramisu_tree.get_iterator_subtree_computations(iterator.name)
+            self.comps = tiramisu_tree.get_iterator_subtree_computations(iterator.id)
             # order the computations by their absolute order
             self.comps.sort(
                 key=lambda comp: tiramisu_tree.computations_absolute_order[comp]

--- a/tiralib/tiramisu/tiramisu_iterator_node.py
+++ b/tiralib/tiramisu/tiramisu_iterator_node.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Tuple
 
 IteratorIdentifier = Tuple[str, int]
 
@@ -7,11 +7,11 @@ class IteratorNode:
     def __init__(
         self,
         name: str,
-        parent_iterator: str | None,
+        parent_iterator: IteratorIdentifier | None,
         lower_bound: int | str,
         upper_bound: int | str,
-        child_iterators: List[str],
-        computations_list: List[str],
+        child_iterators: list[IteratorIdentifier],
+        computations_list: list[str],
         level: int,
         id: IteratorIdentifier = None,
     ):
@@ -47,6 +47,7 @@ class IteratorNode:
 
         return IteratorNode(
             name=self.name + suffix,
+            id=self.id,
             parent_iterator=(
                 self.parent_iterator + suffix if self.parent_iterator else None
             ),


### PR DESCRIPTION
This pull request includes changes to update the iterator identifiers in various test files to use tuple-based identifiers instead of string-based identifiers. The changes ensure consistency in how iterators are referenced across different tests.

The most important changes include:

Updates to iterator identifiers in test files:

* [`tests/tiramisu/test_tiramisu_tree.py`](diffhunk://#diff-02812c0c1b399c4b7debc3c3a33ed87cdcef1fe4905e6cde42645be6475b3fe6L34-R55): Updated iterator identifiers in `test_get_candidate_sections`, `test_get_candidate_computations`, `test_get_root_of_node`, `test_get_iterator_levels`, and `test_get_iterator_of_computation` to use tuple-based identifiers. [[1]](diffhunk://#diff-02812c0c1b399c4b7debc3c3a33ed87cdcef1fe4905e6cde42645be6475b3fe6L34-R55) [[2]](diffhunk://#diff-02812c0c1b399c4b7debc3c3a33ed87cdcef1fe4905e6cde42645be6475b3fe6L64-R81) [[3]](diffhunk://#diff-02812c0c1b399c4b7debc3c3a33ed87cdcef1fe4905e6cde42645be6475b3fe6L85-R99)
* [`tests/tiramisu/tiramisu_actions/test_distribution.py`](diffhunk://#diff-4a18f74534d828bb0c5dd2d40b796899591a7e4521a39a2646167cf66406f6f9L69-R70): Updated iterator identifiers in `test_get_candidates` to use tuple-based identifiers.
* [`tests/tiramisu/tiramisu_actions/test_fusion.py`](diffhunk://#diff-ab6e1e29a7cec11639c80c9294d0467a15fc51f3d36473c6aed392d188c31edfL37-R38): Updated iterator identifiers in `test_get_candidates` to use tuple-based identifiers.
* [`tests/tiramisu/tiramisu_actions/test_interchange.py`](diffhunk://#diff-2ee6b6bf7e10f4342d99f3b443d2877a2de35f3e39c5e024778905132bec735bL42-R45): Updated iterator identifiers in `test_get_candidates` to use tuple-based identifiers.
* [`tests/tiramisu/tiramisu_actions/test_parallelization.py`](diffhunk://#diff-ab28b2e13f52544ced05fd87a17d442593ce482992557de1fce94f4159c85cf0L41-R44): Updated iterator identifiers in `test_get_candidates` to use tuple-based identifiers.
* [`tests/tiramisu/tiramisu_actions/test_reversal.py`](diffhunk://#diff-fdb97b6fae3dd92af12eca77a7dc64ae4b049a63a9929d1ab82fbaeaa1499bdfL40-R42): Updated iterator identifiers in `test_get_candidates` to use tuple-based identifiers.
* [`tests/tiramisu/tiramisu_actions/test_skewing.py`](diffhunk://#diff-d32a9454aea27dd9b0ba555f6fa573e8b3c802c25f0a0266c38b1c44823b230fL43-R62): Updated iterator identifiers in `test_get_candidates` and `test_get_factors` to use tuple-based identifiers.
* [`tests/tiramisu/tiramisu_actions/test_tiling_2d.py`](diffhunk://#diff-45669d9881926d4a6affd7474e5b33a090d0f20ea9dc539624342b623acd5676L43-R47): Updated iterator identifiers in `test_get_candidates` to use tuple-based identifiers.
* [`tests/tiramisu/tiramisu_actions/test_tiling_3d.py`](diffhunk://#diff-bf2405176817476511b5b77d8a32b2c7d2d93f209e065c628f984fe48292c5beL83-R104): Updated iterator identifiers in `test_get_candidates` to use tuple-based identifiers.
* [`tests/tiramisu/tiramisu_actions/test_tiling_general.py`](diffhunk://#diff-39583bcc06a88e0e882d08ba654e4faf921610f38f84569898bdad0ce5e4d6c5L32-L37): Updated iterator identifiers in `test_initialize_action_for_tree` and `test_get_candidates` to use tuple-based identifiers. [[1]](diffhunk://#diff-39583bcc06a88e0e882d08ba654e4faf921610f38f84569898bdad0ce5e4d6c5L32-L37) [[2]](diffhunk://#diff-39583bcc06a88e0e882d08ba654e4faf921610f38f84569898bdad0ce5e4d6c5L69-R119)
* [`tests/tiramisu/tiramisu_actions/test_unrolling.py`](diffhunk://#diff-38849da7cc2544e297a7f8b2e9faa1e1529ef8992c2c8d9d40ae225227e4bf66L46-R53): Updated iterator identifiers in `test_get_candidates` to use tuple-based identifiers.

Updates to utility functions:

* [`tests/utils.py`](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L19-R68): Updated `tree_test_sample`, `tree_test_sample_2`, and `tree_test_sample_3` to use tuple-based identifiers for iterator nodes. [[1]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L19-R68) [[2]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L93-R142) [[3]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L162-R222)