### PR TITLE
feat: add depth property to tree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pyyaml = "^6.0.1"
 [tool.poetry.group.dev.dependencies]
 pytest-cov = "^4.1.0"
 coverage = "^7.2.7"
-ruff = "^0.3.1"
+ruff = "^0.9"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/tiramisu/test_tiramisu_tree.py
+++ b/tests/tiramisu/test_tiramisu_tree.py
@@ -97,3 +97,21 @@ def test_get_iterator_of_computation():
 
     assert t_tree.get_iterator_of_computation("comp01", level=0).name == "root"
     assert t_tree.get_iterator_of_computation("comp03", level=1).name == "j"
+
+
+def test_depth():
+    t_tree = test_utils.tree_test_sample()
+
+    assert t_tree.depth == 4
+
+    t_tree = test_utils.interchange_example().tree
+
+    assert t_tree.depth == 3
+
+    t_tree = test_utils.skewing_example().tree
+
+    assert t_tree.depth == 3
+
+    t_tree = test_utils.tiling_3d_sample().tree
+
+    assert t_tree.depth == 3

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -531,7 +531,7 @@ class CompilingService:
                 consumed_time = sum(results)
                 if consumed_time >= time_budget:
                     logger.debug(
-                        f"No time budget left to perform extra runs. Consumed time:{consumed_time} >= time budget:{time_budget}. Completed {len(results)} out of {min_runs} min_runs and 0 out of {max_runs-min_runs if max_runs else 'inf'} extra runs."
+                        f"No time budget left to perform extra runs. Consumed time:{consumed_time} >= time budget:{time_budget}. Completed {len(results)} out of {min_runs} min_runs and 0 out of {max_runs - min_runs if max_runs else 'inf'} extra runs."
                     )
                 # if a time_budget is set and hasn't been consumed by the min_runs
                 else:
@@ -621,7 +621,7 @@ class CompilingService:
             # run the wrapper
             f"./{tiramisu_program.name}_wrapper"
             if timeout is None
-            else f"timeout {timeout/1000} ./{tiramisu_program.name}_wrapper",
+            else f"timeout {timeout / 1000} ./{tiramisu_program.name}_wrapper",
         ]
 
     @classmethod

--- a/tiralib/tiramisu/function_server.py
+++ b/tiralib/tiramisu/function_server.py
@@ -217,13 +217,12 @@ class FunctionServer:
         """Run the server code."""
         if not BaseConfig.base_config:
             raise ValueError("BaseConfig not initialized")
-        assert (
-            operation
-            in [
-                "execution",
-                "legality",
-            ]
-        ), f"Invalid operation {operation}. Valid operations are: execution, legality, annotations"  # noqa: E501
+        assert operation in [
+            "execution",
+            "legality",
+        ], (
+            f"Invalid operation {operation}. Valid operations are: execution, legality, annotations"
+        )  # noqa: E501
 
         env_vars = " && ".join(
             [

--- a/tiralib/tiramisu/tiramisu_actions/fusion.py
+++ b/tiralib/tiramisu/tiramisu_actions/fusion.py
@@ -86,7 +86,7 @@ class Fusion(TiramisuAction):
         self.tiramisu_optim_str += f"""
 perform_full_dependency_analysis();
     clear_implicit_function_sched_graph();
-    {ordered_computations[0]}{''.join([f'.then({comp},{fusion_level})' for comp, fusion_level in zip(ordered_computations[1:], fusion_levels)])};
+    {ordered_computations[0]}{"".join([f".then({comp},{fusion_level})" for comp, fusion_level in zip(ordered_computations[1:], fusion_levels)])};
     prepare_schedules_for_legality_checks(true);
     std::vector<std::tuple<tiramisu::var, int>> factors = tiramisu::global::get_implicit_function()->correcting_loop_fusion_with_shifting({{{", ".join([f"&{comp}" for comp in computations_of_first_iterator])}}}, {computation_to_fuse}, {{{", ".join([str(i) for i in range(computation_to_fuse_iterator.level + 1)])}}});
     for (const auto &tuple : factors)

--- a/tiralib/tiramisu/tiramisu_actions/matrix.py
+++ b/tiralib/tiramisu/tiramisu_actions/matrix.py
@@ -23,9 +23,9 @@ class MatrixTransform(TiramisuAction):
     def __init__(self, params: List[int], comps: List[str]):
         # MatrixTransform takes the list of parameters of the polyhedral transformation matrix
         # assert that len(params) is a square number (square matrix)
-        assert math.sqrt(len(params)) == int(
-            math.sqrt(len(params))
-        ), "Matrix is not square"
+        assert math.sqrt(len(params)) == int(math.sqrt(len(params))), (
+            "Matrix is not square"
+        )
         assert len(comps) == 1, "MatrixTransform can only be applied to one computation"
         rowLength = int(math.sqrt(len(params)))
         matrix = [params[i : i + rowLength] for i in range(0, len(params), rowLength)]

--- a/tiralib/tiramisu/tiramisu_actions/parallelization.py
+++ b/tiralib/tiramisu/tiramisu_actions/parallelization.py
@@ -64,7 +64,7 @@ class Parallelization(TiramisuAction):
 
         self.str_representation = f"P(L{level},comps={self.comps})"
 
-        self.legality_check_string = f"prepare_schedules_for_legality_checks(true);\n    is_legal &= loop_parallelization_is_legal({level}, {{{', '.join([f'&{comp}' for comp in self.comps]) }}});\n    {self.tiramisu_optim_str}"  # noqa: E501
+        self.legality_check_string = f"prepare_schedules_for_legality_checks(true);\n    is_legal &= loop_parallelization_is_legal({level}, {{{', '.join([f'&{comp}' for comp in self.comps])}}});\n    {self.tiramisu_optim_str}"  # noqa: E501
 
     @classmethod
     def _get_candidates_of_node(

--- a/tiralib/tiramisu/tiramisu_actions/unrolling.py
+++ b/tiralib/tiramisu/tiramisu_actions/unrolling.py
@@ -25,9 +25,9 @@ class Unrolling(TiramisuAction):
         # Unrolling takes 2 parameters: the iterator to unroll and the
         # unrolling factor
         assert len(params) == 2
-        assert isinstance(params[0], tuple) and isinstance(
-            params[1], int
-        ), f"Invalid unrolling parameters: {params}"
+        assert isinstance(params[0], tuple) and isinstance(params[1], int), (
+            f"Invalid unrolling parameters: {params}"
+        )
         self.iterator_id = params[0]
         self.unrolling_factor = params[1]
 

--- a/tiralib/tiramisu/tiramisu_program.py
+++ b/tiralib/tiramisu/tiramisu_program.py
@@ -250,9 +250,9 @@ class TiramisuProgram:
         buffers_init_lines = ""
         for i, buffer_name in enumerate(self.IO_buffer_names):
             buffers_init_lines += f"""
-    double *c_{buffer_name} = (double*)malloc({'*'.join(self.buffer_sizes[i][::-1])}* sizeof(double));
-    parallel_init_buffer(c_{buffer_name}, {'*'.join(self.buffer_sizes[i][::-1])}, (double){str(random.randint(1,10))});
-    Halide::Buffer<double> {buffer_name}(c_{buffer_name}, {','.join(self.buffer_sizes[i][::-1])});
+    double *c_{buffer_name} = (double*)malloc({"*".join(self.buffer_sizes[i][::-1])}* sizeof(double));
+    parallel_init_buffer(c_{buffer_name}, {"*".join(self.buffer_sizes[i][::-1])}, (double){str(random.randint(1, 10))});
+    Halide::Buffer<double> {buffer_name}(c_{buffer_name}, {",".join(self.buffer_sizes[i][::-1])});
     """  # noqa: E501
         if self.name is None:
             raise Exception("TiramisuProgram.name is None")

--- a/tiralib/tiramisu/tiramisu_tree.py
+++ b/tiralib/tiramisu/tiramisu_tree.py
@@ -424,3 +424,7 @@ class TiramisuTree:
             representation += self._get_subtree_representation(root)
 
         return representation
+
+    @property
+    def depth(self) -> int:
+        return max([iterator.level for iterator in self.iterators.values()]) + 1


### PR DESCRIPTION
This pull request introduces a new feature to calculate the depth of a computation tree in the Tiramisu library and adds corresponding tests. The most important changes include the addition of a `depth` property to the `TiramisuTree` class and the creation of a new test function to verify this feature.

### New Feature: Tree Depth Calculation

* [`tiralib/tiramisu/tiramisu_tree.py`](diffhunk://#diff-8313f214082c0d3a682cbd173a128833dfe22126bb8ead4d6278f76ca699e9b9R427-R430): Added a `depth` property to the `TiramisuTree` class to calculate and return the depth of the computation tree.

### Testing

* [`tests/tiramisu/test_tiramisu_tree.py`](diffhunk://#diff-02812c0c1b399c4b7debc3c3a33ed87cdcef1fe4905e6cde42645be6475b3fe6R100-R117): Added a new test function `test_depth` to verify the depth calculation of various tree samples.