### PR TITLE
Fix tiling general behavior

### DIFF
--- a/tests/tiramisu/tiramisu_actions/test_tiling_general.py
+++ b/tests/tiramisu/tiramisu_actions/test_tiling_general.py
@@ -40,23 +40,22 @@ def test_set_string_representations():
     BaseConfig.init()
     sample = test_utils.gramschmidt_sample()
     tiling_general = TilingGeneral(
-        [("R_up_init", 1), ("R_up", 2), ("A_out", 2), 10, 5, 2]
+        [("R_up_init", 1), ("R_up", 2), 10, 5]
     )
     tiling_general.initialize_action_for_tree(sample.tree)
     assert tiling_general.iterators == [
         ("R_up_init", 1),
-        ("R_up", 2),
-        ("A_out", 2),
+        ("R_up", 2)
     ]
 
     assert (
         tiling_general.tiramisu_optim_str
-        == "R_up_init.tile(1, 10);\nR_up.tile(1, 2, 10, 5);\nA_out.tile(1, 2, 10, 2);\n"  # noqa: E501
+        == "R_up_init.tile(1, 10);\nR_up.tile(1, 2, 10, 5);\nA_out.tile(1, 10);\nclear_implicit_function_sched_graph();\n    nrm_init.then(nrm_comp,0).then(R_diag,0).then(Q_out,0).then(R_up_init,0).then(R_up,1).then(A_out,1);\n"  # noqa: E501
     )
 
     assert (
         tiling_general.str_representation
-        == "TG(L1,L2,L2,10,5,2,comps=['R_up_init', 'R_up', 'A_out'])"
+        == "TG(L1,L2,10,5,comps=['R_up_init', 'R_up', 'A_out'])"
     )
 
 

--- a/tests/tiramisu/tiramisu_actions/test_tiling_general.py
+++ b/tests/tiramisu/tiramisu_actions/test_tiling_general.py
@@ -39,14 +39,9 @@ def test_initialize_action_for_tree():
 def test_set_string_representations():
     BaseConfig.init()
     sample = test_utils.gramschmidt_sample()
-    tiling_general = TilingGeneral(
-        [("R_up_init", 1), ("R_up", 2), 10, 5]
-    )
+    tiling_general = TilingGeneral([("R_up_init", 1), ("R_up", 2), 10, 5])
     tiling_general.initialize_action_for_tree(sample.tree)
-    assert tiling_general.iterators == [
-        ("R_up_init", 1),
-        ("R_up", 2)
-    ]
+    assert tiling_general.iterators == [("R_up_init", 1), ("R_up", 2)]
 
     assert (
         tiling_general.tiramisu_optim_str

--- a/tiralib/tiramisu/tiramisu_actions/tiling_general.py
+++ b/tiralib/tiramisu/tiramisu_actions/tiling_general.py
@@ -115,7 +115,7 @@ class TilingGeneral(TiramisuAction):
                 else:
                     # if the comp's branch diverges at this level, no need to check the upcomming levels
                     break
-            if len(loop_levels) >= 1:
+            if len(loop_levels) < 1:
                 raise ValueError("No tiling loop levels found")
 
             loop_levels_and_factors = [str(loop_level) for loop_level in loop_levels]

--- a/tiralib/tiramisu/tiramisu_actions/tiling_general.py
+++ b/tiralib/tiramisu/tiramisu_actions/tiling_general.py
@@ -115,7 +115,8 @@ class TilingGeneral(TiramisuAction):
                 else:
                     # if the comp's branch diverges at this level, no need to check the upcomming levels
                     break
-            assert len(loop_levels) >= 1
+            if len(loop_levels) >= 1:
+                raise ValueError("No tiling loop levels found")
 
             loop_levels_and_factors = [str(loop_level) for loop_level in loop_levels]
             loop_levels_and_factors.extend([str(tile_size) for tile_size in tile_sizes])


### PR DESCRIPTION
Hi,

I noticed that TiraLib's `TilingGeneral` action results in inconsistent behavior and erroneous at times:
1. It doesn't restore the loop structure back after tiling. Meaning that a loop a perfect loop nest might get split into multiple branches after tiling
2. In some instances, it doesn't apply the tiling to all the involved computations, and sometimes it applies it to computations different from the one specified.


For example in [2mm](https://github.com/Tiramisu-Compiler/tiramisu/blob/merge_attempt/benchmarks/autoscheduler_benchmarks/polybench/MEDIUM/function_2mm_MEDIUM/function_2mm_MEDIUM_generator.cpp) if you do `tiramisu_actions.TilingGeneral([('D_beta', 0),('D_beta', 1), 10, 10])` you'll get different result from `tiramisu_actions.Tiling2D([('D_beta', 0),('D_beta', 1), 10, 10]) ` although the two loops are perfectly nested.
Another example on [2mm](https://github.com/Tiramisu-Compiler/tiramisu/blob/merge_attempt/benchmarks/autoscheduler_benchmarks/polybench/MEDIUM/function_2mm_MEDIUM/function_2mm_MEDIUM_generator.cpp) is that if you do `tiramisu_actions.TilingGeneral([('D_prod', 0),('D_prod', 1), 10, 10])` it applies tiling to `D_beta` instead of `D_prod`. Whereas `tiramisu_actions.TilingGeneral([('D_prod', 0),('D_prod', 1), ('D_prod', 2), 10, 10, 10])`  applies to both `D_prod` and `D_beta`

This PR fixes both issues:
- commit af05971c36d08a23f199ab68d80417d1b1503b07 addresses issue 2 by fixing bug in how the involved computation where selected for tiling.
- commit cf889ef96e8b89207e5ed233299cf199940f1099 addresses issue 1 by fusing the computations back after tiling when possible.

These Fixes also solve the false positive case in issue https://github.com/Tiramisu-Compiler/TiraLib/issues/31
