### PR TITLE
feat: Clean TiramisuProgram class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ main.py
 .env
 poetry.lock
 lcov.info
+*.lcov

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ poetry shell
 Then, you can run the tests using the following command:
 
 ```bash
-coverage run -m pytest
+pytest --cov
 ```
 
 Finally, you can generate the coverage report using the following command:

--- a/examples/blur_tiralibcpp_example.py
+++ b/examples/blur_tiralibcpp_example.py
@@ -1,4 +1,5 @@
 # import the tiralib library
+from pathlib import Path
 from tiralib.config import BaseConfig
 from tiralib.tiramisu import Schedule, TiramisuProgram, tiramisu_actions
 
@@ -7,9 +8,9 @@ BaseConfig.init()
 
 # Load the Tiramisu Program from the file and create a TiraLibCPP server
 # IMPORTANT! This needs a working path to the TiraLibCPP library set in the config file of TiraLib
+cpp_code = Path("./examples/function_blur_MINI_generator.cpp").read_text()
 tiramisu_program = TiramisuProgram.init_server(
-    "./examples/function_blur_MINI_generator.cpp",
-    from_file=True,
+    cpp_code=cpp_code,
     load_annotations=True,
     load_tree=True,
     reuse_server=True,

--- a/tests/tiramisu/test_tiramisu_server.py
+++ b/tests/tiramisu/test_tiramisu_server.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import tests.utils as test_utils
 from tiralib.config import BaseConfig
 from tiralib.tiramisu import tiramisu_actions
@@ -8,27 +9,27 @@ from tiralib.tiramisu.tiramisu_program import TiramisuProgram
 def test_init_server():
     BaseConfig.init()
 
+    cpp_code = Path("examples/function_gemver_MINI_generator.cpp").read_text()
     sample = TiramisuProgram.init_server(
-        "examples/function_gemver_MINI_generator.cpp",
+        cpp_code=cpp_code,
         load_isl_ast=True,
         load_tree=True,
-        from_file=True,
     )
 
     assert sample.name == "function_gemver_MINI"
     assert sample.isl_ast_string is not None
-    assert sample.original_str is not None
-    assert sample.comps is not None and len(sample.comps) > 0
+    assert sample.cpp_code is not None
+    assert len(sample.tree.computations) > 0
 
 
 def test_init_server_annotations():
     BaseConfig.init()
 
+    cpp_code = Path("examples/function_gemver_MINI_generator.cpp").read_text()
     sample = TiramisuProgram.init_server(
-        "examples/function_gemver_MINI_generator.cpp",
+        cpp_code=cpp_code,
         load_annotations=True,
         load_tree=True,
-        from_file=True,
         reuse_server=True,
     )
 
@@ -39,11 +40,11 @@ def test_init_server_annotations():
 def test_get_legality():
     BaseConfig.init()
 
+    cpp_code = Path("examples/function_gemver_MINI_generator.cpp").read_text()
     sample = TiramisuProgram.init_server(
-        "examples/function_gemver_MINI_generator.cpp",
+        cpp_code=cpp_code,
         load_isl_ast=True,
         load_tree=True,
-        from_file=True,
         reuse_server=True,
     )
 
@@ -61,11 +62,11 @@ def test_get_legality():
 def test_get_exec_times():
     BaseConfig.init()
 
+    cpp_code = Path("examples/function_gemver_MINI_generator.cpp").read_text()
     sample = TiramisuProgram.init_server(
-        "examples/function_gemver_MINI_generator.cpp",
+        cpp_code=cpp_code,
         load_isl_ast=True,
         load_tree=True,
-        from_file=True,
         reuse_server=True,
     )
 
@@ -86,8 +87,7 @@ def test_get_skewing_factors():
     test_data, test_cpps = test_utils.load_test_data()
 
     tiramisu_func = TiramisuProgram.init_server(
-        # data=test_data["function550013"],
-        original_code=test_cpps["function550013"],
+        cpp_code=test_cpps["function550013"],
         load_annotations=True,
         load_tree=True,
         reuse_server=True,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -345,10 +345,9 @@ def benchmark_program_test_sample():
 def interchange_example() -> TiramisuProgram:
     test_data, test_cpps = load_test_data()
 
-    tiramisu_func = TiramisuProgram.from_dict(
-        name="function837782",
-        data=test_data["function837782"],
-        original_str=test_cpps["function837782"],
+    tiramisu_func = TiramisuProgram.from_annotations(
+        annotations=test_data["function837782"]["program_annotation"],
+        cpp_code=test_cpps["function837782"],
     )
     if tiramisu_func.annotations is None:
         raise ValueError("Annotations not found")
@@ -361,10 +360,9 @@ def interchange_example() -> TiramisuProgram:
 def skewing_example() -> TiramisuProgram:
     test_data, test_cpps = load_test_data()
 
-    tiramisu_func = TiramisuProgram.from_dict(
-        name="function550013",
-        data=test_data["function550013"],
-        original_str=test_cpps["function550013"],
+    tiramisu_func = TiramisuProgram.from_annotations(
+        annotations=test_data["function550013"]["program_annotation"],
+        cpp_code=test_cpps["function550013"],
     )
     if tiramisu_func.annotations is None:
         raise ValueError("Annotations not found")
@@ -377,10 +375,9 @@ def skewing_example() -> TiramisuProgram:
 def reversal_sample() -> TiramisuProgram:
     test_data, test_cpps = load_test_data()
 
-    tiramisu_func = TiramisuProgram.from_dict(
-        name="function824914",
-        data=test_data["function824914"],
-        original_str=test_cpps["function824914"],
+    tiramisu_func = TiramisuProgram.from_annotations(
+        annotations=test_data["function824914"]["program_annotation"],
+        cpp_code=test_cpps["function824914"],
     )
     if tiramisu_func.annotations is None:
         raise ValueError("Annotations not found")
@@ -393,10 +390,9 @@ def reversal_sample() -> TiramisuProgram:
 def unrolling_sample() -> TiramisuProgram:
     test_data, test_cpps = load_test_data()
 
-    tiramisu_func = TiramisuProgram.from_dict(
-        name="function552581",
-        data=test_data["function552581"],
-        original_str=test_cpps["function552581"],
+    tiramisu_func = TiramisuProgram.from_annotations(
+        annotations=test_data["function552581"]["program_annotation"],
+        cpp_code=test_cpps["function552581"],
     )
     if tiramisu_func.annotations is None:
         raise ValueError("Annotations not found")
@@ -409,10 +405,9 @@ def unrolling_sample() -> TiramisuProgram:
 def tiling_2d_sample() -> TiramisuProgram:
     test_data, test_cpps = load_test_data()
 
-    tiramisu_func = TiramisuProgram.from_dict(
-        name="function554520",
-        data=test_data["function554520"],
-        original_str=test_cpps["function554520"],
+    tiramisu_func = TiramisuProgram.from_annotations(
+        annotations=test_data["function554520"]["program_annotation"],
+        cpp_code=test_cpps["function554520"],
     )
     if tiramisu_func.annotations is None:
         raise ValueError("Annotations not found")
@@ -425,10 +420,9 @@ def tiling_2d_sample() -> TiramisuProgram:
 def tiling_3d_sample() -> TiramisuProgram:
     test_data, test_cpps = load_test_data()
 
-    tiramisu_func = TiramisuProgram.from_dict(
-        name="function608722",
-        data=test_data["function608722"],
-        original_str=test_cpps["function608722"],
+    tiramisu_func = TiramisuProgram.from_annotations(
+        annotations=test_data["function608722"]["program_annotation"],
+        cpp_code=test_cpps["function608722"],
     )
     if tiramisu_func.annotations is None:
         raise ValueError("Annotations not found")

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -78,7 +78,7 @@ class CompilingService:
             str: The code to check legality of the schedule
         """
         assert schedule.tiramisu_program
-        assert schedule.tiramisu_program.original_str
+        assert schedule.tiramisu_program.cpp_code
         assert schedule.tree
 
         # Add code to the original file to get legality result
@@ -106,7 +106,7 @@ class CompilingService:
     fct->print_isl_ast_representation();
 """
 
-        cpp_code = schedule.tiramisu_program.original_str.replace(
+        cpp_code = schedule.tiramisu_program.cpp_code.replace(
             schedule.tiramisu_program.code_gen_line, legality_check_lines
         )
         return cpp_code
@@ -124,7 +124,7 @@ class CompilingService:
         if not BaseConfig.base_config:
             raise ValueError("BaseConfig not initialized")
 
-        if not tiramisu_program.original_str:
+        if not tiramisu_program.cpp_code:
             raise ValueError("Tiramisu program not initialized")
 
         output_path = os.path.join(
@@ -139,7 +139,7 @@ class CompilingService:
             std::cout << program_json;
             """  # noqa: E501
 
-        cpp_code = tiramisu_program.original_str.replace(
+        cpp_code = tiramisu_program.cpp_code.replace(
             tiramisu_program.code_gen_line, get_json_lines
         )
         return cls.run_cpp_code(cpp_code=cpp_code, output_path=output_path)
@@ -162,7 +162,7 @@ class CompilingService:
         if not BaseConfig.base_config:
             raise ValueError("BaseConfig not initialized")
 
-        if not tiramisu_program.original_str:
+        if not tiramisu_program.cpp_code:
             raise ValueError("Tiramisu program not initialized")
 
         output_path = os.path.join(
@@ -183,7 +183,7 @@ class CompilingService:
     fct->print_isl_ast_representation();
 """
 
-        cpp_code = tiramisu_program.original_str.replace(
+        cpp_code = tiramisu_program.cpp_code.replace(
             tiramisu_program.code_gen_line, get_isl_ast_lines
         )
         return cls.run_cpp_code(cpp_code=cpp_code, output_path=output_path)
@@ -259,7 +259,6 @@ class CompilingService:
             Tuple[int, int]: The factors to skew the loops by
         """
         assert schedule.tiramisu_program
-        assert schedule.tiramisu_program.comps
 
         if BaseConfig.base_config is None:
             raise Exception("The base config is not loaded yet")
@@ -361,7 +360,7 @@ class CompilingService:
         Returns:
             str: The code to apply the optimizations on the program
         """
-        if not tiramisu_program.original_str:
+        if not tiramisu_program.cpp_code:
             raise ValueError("The program is not loaded yet")
         # Add code to the original file to get the schedule code
         schedule_code = ""
@@ -370,7 +369,7 @@ class CompilingService:
 
         # Add code gen line to the schedule code
         schedule_code += "\n    " + tiramisu_program.code_gen_line + "\n"
-        cpp_code = tiramisu_program.original_str.replace(
+        cpp_code = tiramisu_program.cpp_code.replace(
             tiramisu_program.code_gen_line, schedule_code
         )
         cpp_code = cpp_code.replace(
@@ -436,7 +435,7 @@ class CompilingService:
             raise ValueError("BaseConfig not initialized")
         if (
             not tiramisu_program.name
-            or not tiramisu_program.original_str
+            or not tiramisu_program.cpp_code
             or not tiramisu_program.wrappers
         ):
             raise ValueError("The program is not loaded yet")

--- a/tiralib/tiramisu/function_server.py
+++ b/tiralib/tiramisu/function_server.py
@@ -102,10 +102,8 @@ class FunctionServer:
         if not BaseConfig.base_config:
             raise ValueError("BaseConfig not initialized")
 
-        if not tiramisu_program.original_str:
+        if not tiramisu_program.cpp_code:
             raise ValueError("Tiramisu program not initialized")
-        if not tiramisu_program.wrappers:
-            raise ValueError("Tiramisu program wrappers not initialized")
 
         self.tiramisu_program = tiramisu_program
 
@@ -123,7 +121,7 @@ class FunctionServer:
             return
 
         # Generate the server code
-        server_code = FunctionServer._generate_server_code_from_original_string(
+        server_code = FunctionServer._generate_server_code_from_cpp_code(
             tiramisu_program
         )
 
@@ -149,10 +147,8 @@ class FunctionServer:
         self._compile_server_code()
 
     @classmethod
-    def _generate_server_code_from_original_string(
-        self, tiramisu_program: "TiramisuProgram"
-    ):
-        original_str = tiramisu_program.original_str
+    def _generate_server_code_from_cpp_code(self, tiramisu_program: "TiramisuProgram"):
+        original_str = tiramisu_program.cpp_code
         if original_str is None:
             raise ValueError("Original string not initialized")
         # Generate function
@@ -217,12 +213,13 @@ class FunctionServer:
         """Run the server code."""
         if not BaseConfig.base_config:
             raise ValueError("BaseConfig not initialized")
-        assert operation in [
-            "execution",
-            "legality",
-        ], (
-            f"Invalid operation {operation}. Valid operations are: execution, legality, annotations"
-        )  # noqa: E501
+        assert (
+            operation
+            in [
+                "execution",
+                "legality",
+            ]
+        ), f"Invalid operation {operation}. Valid operations are: execution, legality, annotations"  # noqa: E501
 
         env_vars = " && ".join(
             [

--- a/tiralib/tiramisu/function_server.py
+++ b/tiralib/tiramisu/function_server.py
@@ -213,13 +213,12 @@ class FunctionServer:
         """Run the server code."""
         if not BaseConfig.base_config:
             raise ValueError("BaseConfig not initialized")
-        assert (
-            operation
-            in [
-                "execution",
-                "legality",
-            ]
-        ), f"Invalid operation {operation}. Valid operations are: execution, legality, annotations"  # noqa: E501
+        assert operation in [
+            "execution",
+            "legality",
+        ], (
+            f"Invalid operation {operation}. Valid operations are: execution, legality, annotations"
+        )  # noqa: E501
 
         env_vars = " && ".join(
             [

--- a/tiralib/tiramisu/tiramisu_actions/expansion.py
+++ b/tiralib/tiramisu/tiramisu_actions/expansion.py
@@ -59,7 +59,7 @@ class Expansion(TiramisuAction):
                 f'    std::cout << "{comp}|" << {comp}.expandable() << std::endl;\n'  # noqa
             )
 
-        cpp_code = schedule.tiramisu_program.original_str.replace(
+        cpp_code = schedule.tiramisu_program.cpp_code.replace(
             schedule.tiramisu_program.code_gen_line, candidates_code
         )
 

--- a/tiralib/tiramisu/tiramisu_program.py
+++ b/tiralib/tiramisu/tiramisu_program.py
@@ -1,7 +1,6 @@
 import json
 import random
 import re
-from pathlib import Path
 from typing import Dict
 
 from tiralib.tiramisu.compiling_service import CompilingService
@@ -15,78 +14,85 @@ class TiramisuProgram:
 
     Attributes
     ----------
-    `file_path`: str
-        The path to the cpp file of the tiramisu function
-    `annotations`: dict
-        The tiramisu annotations of the function
-    `comps`: list[str]
-        The list of computations in the function
     `name`: str
         The name of the function
-    `schedules_legality`: dict
-        The legality of the schedules of the function
-    `schedules_solver`: dict
-        The solver results of the schedules of the function
-    `original_str`: str
-        The original code string of the function
-    `initial_execution_times`: dict
-        The initial execution times of the function
-    `current_machine_initial_execution_time`: float
-        The initial execution time of the function on the current machine
+    `cpp_code`: str
+        The code of the function
     `tree`: TiramisuTree
         The tree of the function
+    `IO_buffer_names`: list[str]
+        The names of the input/output buffers
+    `buffer_sizes`: list[list[str]]
+        The sizes of the input/output buffers
+    `annotations`: Dict
+        The annotations of the function
+    `isl_ast_string`: str
+        The isl ast of the function
+    `wrapper_obj`: bytes
+        The wrapper object of the function
+    `server`: FunctionServer
+        TiralibCpp server object
     """
 
     def __init__(self: "TiramisuProgram"):
-        self.file_path = ""
+        self.name: str
+        self.cpp_code: str
+        self.tree: TiramisuTree
+        self.IO_buffer_names: list[str]
+        self.buffer_sizes: list[list[str]]
         self.annotations: Dict | None = None
         self.isl_ast_string: str | None = None
-        self.comps: list[str] | None = None
-        self.name: str | None = None
-        # self.schedules_legality = {}
-        # self.schedules_solver = {}
-        self.schedules_dict: Dict = {}
-        self.original_str: str | None = None
-        self.wrappers: Dict | None = None
-        self.initial_execution_times = {}
-        # self.current_machine_initial_execution_time: float | None = None
-        self.tree: TiramisuTree = None
         self.wrapper_obj: bytes | None = None
         self.server: FunctionServer | None = None
 
+    @property
+    def wrappers(self):
+        buffers_init_lines = ""
+        for i, buffer_name in enumerate(self.IO_buffer_names):
+            buffers_init_lines += f"""
+    double *c_{buffer_name} = (double*)malloc({"*".join(self.buffer_sizes[i][::-1])}* sizeof(double));
+    parallel_init_buffer(c_{buffer_name}, {"*".join(self.buffer_sizes[i][::-1])}, (double){str(random.randint(1, 10))});
+    Halide::Buffer<double> {buffer_name}(c_{buffer_name}, {",".join(self.buffer_sizes[i][::-1])});
+    """  # noqa: E501
+        if self.name is None:
+            raise Exception("TiramisuProgram.name is None")
+
+        wrapper_cpp_code = wrapper_cpp_template.replace("$func_name$", self.name)
+        wrapper_cpp_code = wrapper_cpp_code.replace(
+            "$buffers_init$", buffers_init_lines
+        )
+        wrapper_cpp_code = wrapper_cpp_code.replace(
+            "$func_params$",
+            ",".join([name + ".raw_buffer()" for name in self.IO_buffer_names]),
+        )
+
+        wrapper_h_code = wrapper_h_template.replace("$func_name$", self.name)
+        wrapper_h_code = wrapper_h_code.replace(
+            "$func_params$",
+            ",".join(["halide_buffer_t *" + name for name in self.IO_buffer_names]),
+        )
+
+        return {
+            "cpp": wrapper_cpp_code,
+            "h": wrapper_h_code,
+        }
+
     @classmethod
-    def from_dict(
+    def from_annotations(
         cls,
-        name: str,
-        data: dict,
-        original_str: str | None = None,
-        load_code_lines: bool = True,
+        annotations: dict,
+        cpp_code: str | None = None,
         load_tree: bool = True,
         wrapper_obj: bytes | None = None,
     ) -> "TiramisuProgram":
         # Initiate an instante of the TiramisuProgram class
         tiramisu_prog = cls()
-        tiramisu_prog.name = name
-        tiramisu_prog.annotations = data["program_annotation"]
-        if tiramisu_prog.annotations:
-            tiramisu_prog.comps = list(tiramisu_prog.annotations["computations"].keys())
-        if "schedules_dict" in data:
-            tiramisu_prog.schedules_dict = data["schedules_dict"]
-
-            # Initialize the initial_execution_times attribute and
-            # the current_machine_initial_execution_time attribute
-            if "initial_execution_times" in data:
-                tiramisu_prog.initial_execution_times = data["initial_execution_times"]
-        if load_code_lines:
-            tiramisu_prog.load_code_lines(original_str)
+        tiramisu_prog.cpp_code = cpp_code
+        tiramisu_prog.annotations = annotations
+        tiramisu_prog.load_code_lines()
 
         if wrapper_obj:
             tiramisu_prog.wrapper_obj = wrapper_obj
-
-        # construct the wrapper code
-        wrapper_cpp, wrapper_header = tiramisu_prog.construct_wrapper_code()
-
-        tiramisu_prog.wrappers = {"cpp": wrapper_cpp, "h": wrapper_header}
 
         if load_tree:
             tiramisu_prog.tree = TiramisuTree.from_annotations(
@@ -111,6 +117,10 @@ class TiramisuProgram:
             The path to the cpp file of the tiramisu function
         `load_annotations`: bool
             A flag to indicate if the annotations should be loaded or not
+        `load_isl_ast`: bool
+            A flag to indicate if the isl ast should be loaded or not
+        `load_tree`: bool
+            A flag to indicate if the tree should be constructed or not
 
         Returns
         -------
@@ -118,14 +128,11 @@ class TiramisuProgram:
             An instance of the TiramisuProgram class
         """
         # Initiate an instante of the TiramisuProgram class
+
         tiramisu_prog = cls()
-        tiramisu_prog.file_path = file_path
+        with open(file_path, "r") as f:
+            tiramisu_prog.cpp_code = f.read()
         tiramisu_prog.load_code_lines()
-
-        # load the wrapper code
-        wrapper_cpp, wrapper_header = tiramisu_prog.construct_wrapper_code()
-
-        tiramisu_prog.wrappers = {"cpp": wrapper_cpp, "h": wrapper_header}
 
         if load_annotations:
             tiramisu_prog.annotations = json.loads(
@@ -158,8 +165,7 @@ class TiramisuProgram:
     @classmethod
     def init_server(
         cls,
-        original_code: str,
-        from_file: bool = False,
+        cpp_code: str,
         load_annotations=False,
         load_isl_ast=False,
         load_tree=False,
@@ -167,16 +173,8 @@ class TiramisuProgram:
     ):
         # Initiate an instante of the TiramisuProgram class
         tiramisu_prog = cls()
-        if from_file:
-            tiramisu_prog.file_path = original_code
-            tiramisu_prog.load_code_lines()
-        else:
-            tiramisu_prog.load_code_lines(original_code)
-        # load the wrapper code
-        wrapper_cpp, wrapper_header = tiramisu_prog.construct_wrapper_code()
-
-        tiramisu_prog.wrappers = {"cpp": wrapper_cpp, "h": wrapper_header}
-
+        tiramisu_prog.cpp_code = cpp_code
+        tiramisu_prog.load_code_lines()
         tiramisu_prog.server = FunctionServer(tiramisu_prog, reuse_server=reuse_server)
 
         if load_annotations:
@@ -205,77 +203,25 @@ class TiramisuProgram:
         # After taking the neccessary fields return the instance
         return tiramisu_prog
 
-    def load_code_lines(self, original_str: str | None = None):
+    def load_code_lines(self):
         """This function loads the file code , it is necessary to generate
         legality check code and annotations
         """
-        if original_str:
-            self.original_str = original_str
-        else:
-            with open(self.file_path, "r") as f:
-                self.original_str = f.read()
-
-        self.func_folder = (
-            "/".join(Path(self.file_path).parts[:-1])
-            if len(Path(self.file_path).parts) > 1
-            else "."
-        ) + "/"
-        self.body = re.findall(
-            r"int main\([\w\s,*]+\)\s*\{([\W\w\s]*)tiramisu::codegen",
-            self.original_str,
-        )[0]
-        self.name = re.findall(r"tiramisu::init\(\"(\w+)\"\);", self.original_str)[0]
+        self.name = re.findall(r"tiramisu::init\(\"(\w+)\"\);", self.cpp_code)[0]
         # Remove the wrapper include from the original string
         self.wrapper_str = f'#include "{self.name}_wrapper.h"'
-        self.original_str = self.original_str.replace(
+        self.cpp_code = self.cpp_code.replace(
             self.wrapper_str, f"// {self.wrapper_str}"
         )
-        self.comps = re.findall(r"computation (\w+)\(", self.original_str)
-        self.code_gen_line = re.findall(r"tiramisu::codegen\({.+;", self.original_str)[
-            0
-        ]
+        self.code_gen_line = re.findall(r"tiramisu::codegen\({.+;", self.cpp_code)[0]
         buffers_vect = re.findall(r"{(.+)}", self.code_gen_line)[0]
         self.IO_buffer_names = re.findall(r"\w+", buffers_vect)
         self.buffer_sizes = []
         for buf_name in self.IO_buffer_names:
-            sizes_vect = re.findall(
-                r"buffer " + buf_name + ".*{(.*)}", self.original_str
-            )[0]
+            sizes_vect = re.findall(r"buffer " + buf_name + ".*{(.*)}", self.cpp_code)[
+                0
+            ]
             self.buffer_sizes.append(re.findall(r"\d+", sizes_vect))
-        self.wrapper_is_compiled = False
-
-    def construct_wrapper_code(
-        self,
-    ):  # construct the wrapper.cpp and wrapper.h from the program
-        buffers_init_lines = ""
-        for i, buffer_name in enumerate(self.IO_buffer_names):
-            buffers_init_lines += f"""
-    double *c_{buffer_name} = (double*)malloc({"*".join(self.buffer_sizes[i][::-1])}* sizeof(double));
-    parallel_init_buffer(c_{buffer_name}, {"*".join(self.buffer_sizes[i][::-1])}, (double){str(random.randint(1, 10))});
-    Halide::Buffer<double> {buffer_name}(c_{buffer_name}, {",".join(self.buffer_sizes[i][::-1])});
-    """  # noqa: E501
-        if self.name is None:
-            raise Exception("TiramisuProgram.name is None")
-
-        wrapper_cpp_code = wrapper_cpp_template.replace("$func_name$", self.name)
-        wrapper_cpp_code = wrapper_cpp_code.replace(
-            "$buffers_init$", buffers_init_lines
-        )
-        wrapper_cpp_code = wrapper_cpp_code.replace(
-            "$func_folder_path$", self.func_folder
-        )
-        wrapper_cpp_code = wrapper_cpp_code.replace(
-            "$func_params$",
-            ",".join([name + ".raw_buffer()" for name in self.IO_buffer_names]),
-        )
-
-        wrapper_h_code = wrapper_h_template.replace("$func_name$", self.name)
-        wrapper_h_code = wrapper_h_code.replace(
-            "$func_params$",
-            ",".join(["halide_buffer_t *" + name for name in self.IO_buffer_names]),
-        )
-
-        return wrapper_cpp_code, wrapper_h_code
 
     def __str__(self) -> str:
         return f"TiramisuProgram(name={self.name})"


### PR DESCRIPTION
This pull request includes several changes to the Tiramisu library and its examples, focusing on updating the way C++ code is handled and improving test coverage. The most important changes include replacing the use of `original_str` with `cpp_code`, updating examples to use `Path` for reading files, and modifying test cases accordingly.

### Codebase Simplification:

* Replaced `original_str` with `cpp_code` in various methods and assertions across multiple files to standardize the handling of C++ code. (`tiralib/tiramisu/compiling_service.py`, `tiralib/tiramisu/function_server.py`, `tiralib/tiramisu/tiramisu_program.py`) [[1]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L81-R81) [[2]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L109-R109) [[3]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L127-R127) [[4]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L142-R142) [[5]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L165-R165) [[6]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L186-R186) [[7]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L262) [[8]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L364-R363) [[9]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L373-R372) [[10]](diffhunk://#diff-e208dcee0560e47ba027b51b312d2843cc5b89bc0363781a6eb36c19e43ccc07L439-R438) [[11]](diffhunk://#diff-0a2ac3056cbee2a8b7085bb17dba9d4ba7cb3de5b870ae2c91c7629d1d70dbb9L105-L108) [[12]](diffhunk://#diff-0a2ac3056cbee2a8b7085bb17dba9d4ba7cb3de5b870ae2c91c7629d1d70dbb9L126-R124) [[13]](diffhunk://#diff-0a2ac3056cbee2a8b7085bb17dba9d4ba7cb3de5b870ae2c91c7629d1d70dbb9L152-R151) [[14]](diffhunk://#diff-8276c79f97e2146500d1a1ae36353addc57d05e12bf3013f46bb8e2da7da363cL62-R62)

### Example Updates:

* Updated `examples/blur_tiralibcpp_example.py` to use `Path` for reading the C++ code from files, improving readability and consistency. [[1]](diffhunk://#diff-6911db71a090154564d7ed4eaf39f530fa7fcb690b4fe25e950069fa6b2ea72eR2) [[2]](diffhunk://#diff-6911db71a090154564d7ed4eaf39f530fa7fcb690b4fe25e950069fa6b2ea72eR11-R13)

### Test Improvements:

* Modified test cases in `tests/tiramisu/test_tiramisu_server.py` to use `cpp_code` instead of file paths, ensuring tests are more robust and less dependent on external files. [[1]](diffhunk://#diff-94d77f35ef25ec4ed21f063c597189df778c3c4e45efa865645fa5e15943271aR1) [[2]](diffhunk://#diff-94d77f35ef25ec4ed21f063c597189df778c3c4e45efa865645fa5e15943271aR12-L31) [[3]](diffhunk://#diff-94d77f35ef25ec4ed21f063c597189df778c3c4e45efa865645fa5e15943271aR43-L46) [[4]](diffhunk://#diff-94d77f35ef25ec4ed21f063c597189df778c3c4e45efa865645fa5e15943271aR65-L68) [[5]](diffhunk://#diff-94d77f35ef25ec4ed21f063c597189df778c3c4e45efa865645fa5e15943271aL89-R90)
* Updated utility functions in `tests/utils.py` to use `from_annotations` instead of `from_dict`, aligning with the new handling of `cpp_code`. [[1]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L348-R350) [[2]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L364-R365) [[3]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L380-R380) [[4]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L396-R395) [[5]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L412-R410) [[6]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L428-R425)

### Documentation:

* Simplified the test command in `README.md` to use `pytest --cov` instead of `coverage run -m pytest`, making it more concise.