### PR TITLE
fix: export TiramisuServer from tiramisu module

### DIFF
--- a/tiralib/tiramisu/__init__.py
+++ b/tiralib/tiramisu/__init__.py
@@ -7,6 +7,7 @@ from .schedule import Schedule
 from .tiramisu_iterator_node import IteratorIdentifier, IteratorNode
 from .tiramisu_program import TiramisuProgram
 from .tiramisu_tree import TiramisuTree
+from .function_server import FunctionServer
 
 __all__ = [
     "CompilingService",
@@ -16,4 +17,5 @@ __all__ = [
     "IteratorNode",
     "tiramisu_actions",
     "IteratorIdentifier",
+    "FunctionServer",
 ]

--- a/tiralib/tiramisu/tiramisu_program.py
+++ b/tiralib/tiramisu/tiramisu_program.py
@@ -170,7 +170,7 @@ class TiramisuProgram:
         load_isl_ast=False,
         load_tree=False,
         reuse_server=False,
-    ):
+    ) -> "TiramisuProgram":
         # Initiate an instante of the TiramisuProgram class
         tiramisu_prog = cls()
         tiramisu_prog.cpp_code = cpp_code


### PR DESCRIPTION
* [`tiralib/tiramisu/__init__.py`](diffhunk://#diff-340f91ce93273ec88af6e66aa4d3696534f36cb1be6e54afd754451c66c913eeR10): Imported the `FunctionServer` module to make it available for use within the library.
* [`tiralib/tiramisu/__init__.py`](diffhunk://#diff-340f91ce93273ec88af6e66aa4d3696534f36cb1be6e54afd754451c66c913eeR20): Updated the `__all__` list to include `FunctionServer`, ensuring it is exposed as part of the library's public API.
* [`tiralib/tiramisu/tiramisu_program.py`](diffhunk://#diff-e52a20c1520e22b202784a513fc9fb10a1ae61773b68ff1d43ca28acf579df4eL173-R173): Added a return type annotation to the `init_server` method, specifying that it returns an instance of `TiramisuProgram`.