### PR TITLE
fix: fix upper bound coming from isl ast 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,7 +3,7 @@
 
 name: Python package
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   format:

--- a/tiralib/tiramisu/tiramisu_tree.py
+++ b/tiralib/tiramisu/tiramisu_tree.py
@@ -183,7 +183,8 @@ class TiramisuTree:
                 else:
                     upper_bound = loop_condition
                 try:
-                    upper_bound = int(upper_bound)
+                    # isl has <= so we add 1 to the upper bound
+                    upper_bound = int(upper_bound) + 1
                 except ValueError:
                     # Upper bound is not an integer so we keep it string
                     pass
@@ -428,3 +429,39 @@ class TiramisuTree:
     @property
     def depth(self) -> int:
         return max([iterator.level for iterator in self.iterators.values()]) + 1
+
+    def get_isl_ast_string(self) -> str:
+        representation = ""
+        for root in self.roots:
+            representation += self._get_isl_ast_string_of_node(root)
+        return representation
+
+    def _get_isl_ast_string_of_node(self, node_id: IteratorIdentifier) -> str:
+        representation = ""
+        iterator = self.iterators[node_id]
+        representation += f"{iterator.name}|iterator|{iterator.lower_bound}|{iterator.name} <= {iterator.upper_bound}|1\n"
+        comps_and_iterators = [
+            (comp, "comp") for comp in self.iterators[node_id].computations_list
+        ]
+        comps_and_iterators += [
+            (iterator, "iterator")
+            for iterator in self.iterators[node_id].child_iterators
+        ]
+
+        # sort them by computations_absolute_order
+        comps_and_iterators = sorted(
+            comps_and_iterators,
+            key=lambda item: (
+                self.computations_absolute_order[item[0]]
+                if item[1] == "comp"
+                else self.computations_absolute_order[item[0][0]]
+            ),
+        )
+
+        for comp_or_iterator, type in comps_and_iterators:
+            if type == "comp":
+                representation += f"{iterator.level+1}|computation|{comp_or_iterator}\n"
+
+            else:
+                representation += self._get_isl_ast_string_of_node(comp_or_iterator)
+        return representation

--- a/tiralib/tiramisu/tiramisu_tree.py
+++ b/tiralib/tiramisu/tiramisu_tree.py
@@ -439,7 +439,14 @@ class TiramisuTree:
     def _get_isl_ast_string_of_node(self, node_id: IteratorIdentifier) -> str:
         representation = ""
         iterator = self.iterators[node_id]
-        representation += f"{iterator.name}|iterator|{iterator.lower_bound}|{iterator.name} <= {iterator.upper_bound}|1\n"
+        upper_bound_str = (
+            f"{iterator.name} <= {iterator.upper_bound-1}"
+            if isinstance(iterator.upper_bound, int)
+            else iterator.upper_bound
+        )
+        representation += (
+            f"{iterator.name}|iterator|{iterator.lower_bound}|{upper_bound_str}|1\n"
+        )
         comps_and_iterators = [
             (comp, "comp") for comp in self.iterators[node_id].computations_list
         ]

--- a/tiralib/tiramisu/tiramisu_tree.py
+++ b/tiralib/tiramisu/tiramisu_tree.py
@@ -440,7 +440,7 @@ class TiramisuTree:
         representation = ""
         iterator = self.iterators[node_id]
         upper_bound_str = (
-            f"{iterator.name} <= {iterator.upper_bound-1}"
+            f"{iterator.name} <= {iterator.upper_bound - 1}"
             if isinstance(iterator.upper_bound, int)
             else iterator.upper_bound
         )
@@ -467,7 +467,9 @@ class TiramisuTree:
 
         for comp_or_iterator, type in comps_and_iterators:
             if type == "comp":
-                representation += f"{iterator.level+1}|computation|{comp_or_iterator}\n"
+                representation += (
+                    f"{iterator.level + 1}|computation|{comp_or_iterator}\n"
+                )
 
             else:
                 representation += self._get_isl_ast_string_of_node(comp_or_iterator)


### PR DESCRIPTION
This pull request to `tiralib/tiramisu/tiramisu_tree.py` includes changes to improve the handling of upper bounds and adds new methods for generating ISL AST strings. The most important changes include modifying the upper bound calculation and adding methods to generate ISL AST string representations of the tiramisu tree.

Improvements to upper bound handling:

* Modified the `from_isl_ast_string_list` method to add 1 to the upper bound when converting it to an integer to account for the ISL's inclusive upper bound.

Enhancements to ISL AST string generation:

* Added a new method `get_isl_ast_string` to generate the ISL AST string representation of the tiramisu tree.
* Added a helper method `_get_isl_ast_string_of_node` to recursively generate the ISL AST string for each node in the tiramisu tree.