### PR TITLE
Fix schedule tree rebuild: merge duplicated ISL iterator blocks instead of overwriting

### DIFF
--- a/tiralib/tiramisu/tiramisu_actions/fusion.py
+++ b/tiralib/tiramisu/tiramisu_actions/fusion.py
@@ -101,7 +101,7 @@ perform_full_dependency_analysis();
 """  # noqa: E501
 
         self.str_representation = (
-            f"F(L{self.params[0][1]},comps=[{self.params[0][0]},{self.params[1][0]}])"
+            f"F(L{self.params[0][1]},comps=['{self.params[0][0]}', '{self.params[1][0]}'])"
         )
 
         self.legality_check_string = (

--- a/tiralib/tiramisu/tiramisu_actions/fusion.py
+++ b/tiralib/tiramisu/tiramisu_actions/fusion.py
@@ -100,9 +100,7 @@ perform_full_dependency_analysis();
     }}
 """  # noqa: E501
 
-        self.str_representation = (
-            f"F(L{self.params[0][1]},comps=['{self.params[0][0]}', '{self.params[1][0]}'])"
-        )
+        self.str_representation = f"F(L{self.params[0][1]},comps=['{self.params[0][0]}', '{self.params[1][0]}'])"
 
         self.legality_check_string = (
             self.tiramisu_optim_str + "\n    is_legal &= factors.size() > 0;\n"


### PR DESCRIPTION
When applying fusion, ISL AST may contain duplicated computation blocks (from loop splitting). While rebuilding `schedule.tree` from the ISL AST, iterator nodes were keyed by `(first_comp, level)`, so blocks sharing the same first computation would overwrite earlier ones, causing computations that only appear in earlier blocks to be dropped.

This change avoids overwriting existing iterator nodes for duplicate iterator IDs and instead unions their `child_iterators` / `computations_list` (deduped). Loop bounds remain unchanged/ignored since they’re values are not used in Tiralib at the moment.
