### PR TITLE
Support `U(L-1, ...)` and tolerate looser schedule strings

### DIFF
--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -132,6 +132,33 @@ def test_str_representation():
     assert str(schedule) == "P(L0,comps=['comp02'])"
 
 
+def test_from_sched_str_unrolling_l_neg_1():
+    BaseConfig.init()
+
+    # Pre-tiling: innermost level of `w` in gemver is 1 (it's a 2D loop).
+    test_program = test_utils.multiple_roots_sample()
+    pre_schedule = Schedule.from_sched_str(
+        "U(L-1,4,comps=['w'])", test_program
+    )
+    assert pre_schedule is not None
+    pre_unrolling = pre_schedule.optims_list[0]
+    pre_level = pre_unrolling.iterator_id[1]
+    assert pre_level == 1
+    # Serialization carries the resolved level, not L-1.
+    assert "L-1" not in str(pre_schedule)
+    assert "L1" in str(pre_schedule)
+
+    # Post-tiling: T2 on (w,0)(w,1) introduces 2 new loops; the new
+    # innermost level for `w` should be deeper than before.
+    post_schedule = Schedule.from_sched_str(
+        "T2(L0,L1,32,32,comps=['w'])|U(L-1,4,comps=['w'])", test_program
+    )
+    assert post_schedule is not None
+    post_unrolling = post_schedule.optims_list[1]
+    post_level = post_unrolling.iterator_id[1]
+    assert post_level > pre_level
+
+
 def test_from_sched_str():
     BaseConfig.init()
 

--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -137,9 +137,7 @@ def test_from_sched_str_unrolling_l_neg_1():
 
     # Pre-tiling: innermost level of `w` in gemver is 1 (it's a 2D loop).
     test_program = test_utils.multiple_roots_sample()
-    pre_schedule = Schedule.from_sched_str(
-        "U(L-1,4,comps=['w'])", test_program
-    )
+    pre_schedule = Schedule.from_sched_str("U(L-1,4,comps=['w'])", test_program)
     assert pre_schedule is not None
     pre_unrolling = pre_schedule.optims_list[0]
     pre_level = pre_unrolling.iterator_id[1]

--- a/tests/tiramisu/tiramisu_actions/test_unrolling.py
+++ b/tests/tiramisu/tiramisu_actions/test_unrolling.py
@@ -1,3 +1,5 @@
+import pytest
+
 import tests.utils as test_utils
 from tiralib.tiramisu.schedule import Schedule
 from tiralib.tiramisu.tiramisu_actions.unrolling import Unrolling
@@ -37,6 +39,26 @@ def test_set_string_representations():
         reversal.legality_check_string
         == "prepare_schedules_for_legality_checks(true);\n    is_legal &= loop_unrolling_is_legal(0, {&comp00});\n    comp00.unroll(0,4);"  # noqa: E501
     )
+
+
+def test_initialize_action_for_tree_l_neg_1():
+    BaseConfig.init()
+    sample = test_utils.unrolling_sample()
+    unrolling = Unrolling([("comp00", -1), 4])
+    unrolling.initialize_action_for_tree(sample.tree)
+    # comp00's innermost level in the sample is 1
+    assert unrolling.iterator_id == ("comp00", 1)
+    assert unrolling.tiramisu_optim_str == "comp00.unroll(1,4);"
+    assert unrolling.str_representation == "U(L1,4,comps=['comp00'])"
+
+
+def test_initialize_action_for_tree_l_neg_1_mismatch():
+    BaseConfig.init()
+    tree = test_utils.tree_test_sample()
+    # comp01's innermost depth is 1, comp03's is 3 — must error.
+    unrolling = Unrolling([("comp01", -1), 4], ["comp01", "comp03"])
+    with pytest.raises(ValueError):
+        unrolling.initialize_action_for_tree(tree)
 
 
 def test_get_candidates():

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -228,7 +228,10 @@ class Schedule:
     ) -> "Schedule":
         schedule = cls(tiramisu_program)
         assert schedule.tree
-        sched_str = sched_str.replace('"', "'")
+        # Normalize: collapse all whitespace and canonicalize quotes so the
+        # per-action regexes can stay strict. Tiramisu identifiers are \w+,
+        # so stripping whitespace inside the schedule string is lossless.
+        sched_str = re.sub(r"\s+", "", sched_str).replace('"', "'")
         for optimization_str in sched_str.split("|"):
             if optimization_str == "":
                 continue

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -251,7 +251,7 @@ class Schedule:
             elif optimization_str[0] == "U":
                 # extract loop level, factor and comps using
                 # U\(L(\d),(\d+),comps=\[([\w',]*)\]\)
-                regex = r"U\(L(\d),(\d+),comps=\[([\w', ]*)\]\)"
+                regex = r"U\(L(-?\d+),(\d+),comps=\[([\w', ]*)\]\)"
                 match = re.match(regex, optimization_str)
                 if match:
                     loop_level = int(match.group(1))

--- a/tiralib/tiramisu/tiramisu_actions/unrolling.py
+++ b/tiralib/tiramisu/tiramisu_actions/unrolling.py
@@ -39,6 +39,36 @@ class Unrolling(TiramisuAction):
     def initialize_action_for_tree(self, tiramisu_tree: TiramisuTree):
         # clone the tree to be able to restore it later
         self.tree = copy.deepcopy(tiramisu_tree)
+
+        comp_name, level = self.iterator_id
+        if level == -1:
+            # L-1 means "innermost loop after previously applied
+            # transformations"; resolve against the current tree state.
+            def innermost_level_of(comp: str) -> int:
+                levels = [
+                    it.level
+                    for it in tiramisu_tree.iterators.values()
+                    if comp in it.computations_list
+                ]
+                if not levels:
+                    raise ValueError(
+                        f"Cannot resolve L-1 for unrolling: computation "
+                        f"{comp!r} is not in the current tree."
+                    )
+                return max(levels)
+
+            reference_comps = self.comps or [comp_name]
+            innermost_levels = {c: innermost_level_of(c) for c in reference_comps}
+            unique_levels = set(innermost_levels.values())
+            if len(unique_levels) > 1:
+                raise ValueError(
+                    "U(L-1,...) requires all target computations to share "
+                    f"the same innermost loop depth; got {innermost_levels}. "
+                    "Split non-perfectly-nested computations into separate "
+                    "U(...) actions."
+                )
+            self.iterator_id = (comp_name, unique_levels.pop())
+
         if self.iterator_id not in tiramisu_tree.iterators:
             self.iterator_id = self.tree.get_iterator_of_computation(
                 *self.iterator_id


### PR DESCRIPTION
`U(L-1, ...)` resolves to the current innermost loop of the targeted computation, against the tree state after any earlier transformations in the same schedule. So `T2(L0,L1,32,32,comps=['comp00'])|U(L-1,4,comps=['comp00'])` unrolls the new innermost loop introduced by the tile.

Multi-comp `U(L-1, ...)` with mismatched depths raises `ValueError` — non-perfectly-nested comps need separate `U(...)` actions.

`from_sched_str` now normalizes input (whitespace + quotes) up front, so `U(L-1, 4, comps=["comp_A"])` parses the same as `U(L-1,4,comps=['comp_A'])`. Per-action regexes stay strict.

Serialization carries the resolved level, so `Schedule.from_sched_str(str(schedule))` still round-trips.

Tests added in `tests/tiramisu/tiramisu_actions/test_unrolling.py` and `tests/tiramisu/test_schedule.py`.