### PR TITLE
Catch invalid schedule tokens in `from_sched_str`

### DIFF
--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -1,3 +1,5 @@
+import pytest
+
 import tests.utils as test_utils
 from tiralib.tiramisu import tiramisu_actions
 from tiralib.tiramisu.schedule import Schedule
@@ -230,3 +232,18 @@ def test_from_sched_str():
 
     for idx, optim in enumerate(schedule.optims_list):
         assert optim == new_schedule.optims_list[idx]
+
+
+def test_from_sched_str_unknown_action_raises():
+    BaseConfig.init()
+    test_program = benchmark_program_test_sample()
+    with pytest.raises(ValueError, match="Failed to parse schedule token"):
+        Schedule.from_sched_str("Z(L0,comps=['comp02'])", test_program)
+
+
+def test_from_sched_str_malformed_body_raises():
+    BaseConfig.init()
+    test_program = benchmark_program_test_sample()
+    # Known leading char "P" but missing the closing paren.
+    with pytest.raises(ValueError, match="Failed to parse schedule token"):
+        Schedule.from_sched_str("P(L0,comps=['comp02']", test_program)

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -235,6 +235,7 @@ class Schedule:
         for optimization_str in sched_str.split("|"):
             if optimization_str == "":
                 continue
+            prev_count = len(schedule.optims_list)
             if optimization_str[0] == "P":
                 # extract loop level and comps using P\(L(\d),comps=\[([\w',]*)
                 regex = r"P\(L(\d),comps=\[([\w', ]*)\]\)"
@@ -428,6 +429,14 @@ class Schedule:
             elif optimization_str[:2] == "TG":
                 raise NotImplementedError
                 # regex =
+
+            if len(schedule.optims_list) == prev_count:
+                # Either the leading character matched no branch, or the
+                # branch's regex didn't match the body. Surface it instead
+                # of silently dropping the token.
+                raise ValueError(
+                    f"Failed to parse schedule token: {optimization_str!r}"
+                )
 
         return schedule
 


### PR DESCRIPTION
Before, `from_sched_str` would silently skip any token whose leading character didn't match a branch or whose body didn't match the branch's regex. You'd get back a `Schedule` with fewer actions than tokens and no warning.

Now any unparseable token raises `ValueError("Failed to parse schedule token: ...")`. Implemented as a single post-dispatch check (length of `optims_list` before vs. after) so adding new actions doesn't require remembering to add an error path.

Tests for an unknown action (`Z(...)`) and a malformed body (missing close paren) added in `tests/tiramisu/test_schedule.py`.
