### PR TITLE
Fix schedule replay and legality checks

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,6 +64,7 @@ jobs:
 
     - name: Install TiraLibCPP
       run: |
+        apt update
         apt install -y sqlite3 libsqlite3-dev zlib1g-dev
         git clone https://github.com/skourta/TiraLibCpp.git
         cd TiraLibCpp

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: skourta/tiramisu:latest
+      image: mascinissa/tiramisu:looper_master
     strategy:
       fail-fast: false
       matrix:

--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -162,9 +162,7 @@ def test_from_sched_str_unrolling_l_neg_1():
 def test_from_sched_str_preserves_unrolling_computations():
     test_program = test_utils.fusion_sample()
 
-    parsed_schedule = Schedule.from_sched_str(
-        "U(L2,4,comps=['comp03'])", test_program
-    )
+    parsed_schedule = Schedule.from_sched_str("U(L2,4,comps=['comp03'])", test_program)
     parsed_unrolling = parsed_schedule.optims_list[0]
 
     assert parsed_unrolling.comps == ["comp03"]
@@ -245,9 +243,7 @@ def test_from_sched_str():
 
     schedule.add_optimizations(
         [
-            tiramisu_actions.Skewing(
-                [("x_temp", 0), ("x_temp", 1), 1, 0, 1, 1]
-            ),
+            tiramisu_actions.Skewing([("x_temp", 0), ("x_temp", 1), 1, 0, 1, 1]),
         ]
     )
 
@@ -293,8 +289,7 @@ def test_from_sched_str_preserves_parallelization_computations():
     parallelization = schedule.optims_list[0]
     assert parallelization.comps == ["A_hat", "x_temp"]
     assert parallelization.tiramisu_optim_str == (
-        "A_hat.tag_parallel_level(0);\n"
-        "x_temp.tag_parallel_level(0);\n"
+        "A_hat.tag_parallel_level(0);\nx_temp.tag_parallel_level(0);\n"
     )
 
 

--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -208,6 +208,24 @@ def test_from_sched_str():
     for idx, optim in enumerate(schedule.optims_list):
         assert optim == new_schedule.optims_list[idx]
 
+    schedule = Schedule(test_program)
+    assert schedule.tree
+
+    schedule.add_optimizations(
+        [
+            tiramisu_actions.Skewing(
+                [("x_temp", 0), ("x_temp", 1), 1, 0, 1, 1]
+            ),
+        ]
+    )
+
+    sched_str = str(schedule)
+    new_schedule = Schedule.from_sched_str(sched_str, test_program)
+
+    assert new_schedule is not None
+    assert len(new_schedule.optims_list) == len(schedule.optims_list)
+    assert schedule.optims_list == new_schedule.optims_list
+
     test_program = test_utils.tiling_3d_sample()
 
     schedule = Schedule(test_program)

--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -250,6 +250,22 @@ def test_from_sched_str():
         assert optim == new_schedule.optims_list[idx]
 
 
+def test_from_sched_str_preserves_parallelization_computations():
+    BaseConfig.init()
+    test_program = test_utils.multiple_roots_sample()
+
+    schedule = Schedule.from_sched_str(
+        "P(L0,comps=['A_hat','x_temp','A_hat'])", test_program
+    )
+
+    parallelization = schedule.optims_list[0]
+    assert parallelization.comps == ["A_hat", "x_temp"]
+    assert parallelization.tiramisu_optim_str == (
+        "A_hat.tag_parallel_level(0);\n"
+        "x_temp.tag_parallel_level(0);\n"
+    )
+
+
 def test_from_sched_str_unknown_action_raises():
     BaseConfig.init()
     test_program = benchmark_program_test_sample()

--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -159,6 +159,38 @@ def test_from_sched_str_unrolling_l_neg_1():
     assert post_level > pre_level
 
 
+def test_from_sched_str_preserves_unrolling_computations():
+    test_program = test_utils.fusion_sample()
+
+    parsed_schedule = Schedule.from_sched_str(
+        "U(L2,4,comps=['comp03'])", test_program
+    )
+    parsed_unrolling = parsed_schedule.optims_list[0]
+
+    assert parsed_unrolling.comps == ["comp03"]
+    assert parsed_unrolling.legality_comps == ["comp03", "comp04"]
+    assert parsed_unrolling.tiramisu_optim_str == "comp03.unroll(2,4);"
+    assert str(parsed_schedule) == "U(L2,4,comps=['comp03'])"
+    assert parsed_schedule.get_legality_str() == (
+        "UCheck(L2,4,comps=['comp03', 'comp04'])"
+    )
+    assert "loop_unrolling_is_legal" in parsed_unrolling.legality_check_string
+    assert ".unroll(" not in parsed_unrolling.legality_check_string
+
+    # Omitting `comps` from the action API must retain the original behavior:
+    # infer every computation in the selected iterator subtree.
+    inferred_schedule = Schedule(test_program)
+    inferred_unrolling = tiramisu_actions.Unrolling([("comp03", 2), 4])
+    inferred_schedule.add_optimizations([inferred_unrolling])
+
+    assert inferred_unrolling.comps == ["comp03", "comp04"]
+    assert inferred_unrolling.legality_comps == ["comp03", "comp04"]
+    assert "comp03.unroll(2,4);" in inferred_unrolling.tiramisu_optim_str
+    assert "comp04.unroll(2,4);" in inferred_unrolling.tiramisu_optim_str
+    assert "comp03.unroll(2,4);" in inferred_unrolling.legality_check_string
+    assert "comp04.unroll(2,4);" in inferred_unrolling.legality_check_string
+
+
 def test_from_sched_str():
     BaseConfig.init()
 

--- a/tests/tiramisu/tiramisu_actions/test_parallelization.py
+++ b/tests/tiramisu/tiramisu_actions/test_parallelization.py
@@ -13,6 +13,11 @@ def test_parallelization_init():
     assert parallelization.iterator_id == ("comp01", 1)
     assert parallelization.comps == ["comp01"]
 
+    parallelization = Parallelization(
+        [("comp01", 1)], comps=["comp01", "comp01"]
+    )
+    assert parallelization.comps == ["comp01"]
+
 
 def test_initialize_action_for_tree():
     t_tree = test_utils.tree_test_sample()
@@ -31,6 +36,30 @@ def test_set_string_representations():
     schedule.add_optimizations([parallelization])
 
     assert parallelization.tiramisu_optim_str == "comp02.tag_parallel_level(0);\n"
+
+
+def test_set_string_representations_tags_each_distinct_computation():
+    t_tree = test_utils.tree_test_sample_2()
+    parallelization = Parallelization(
+        [("comp05", 1)],
+        comps=["comp05", "comp06", "comp06", "comp07"],
+    )
+    parallelization.initialize_action_for_tree(t_tree)
+
+    assert parallelization.comps == ["comp05", "comp06", "comp07"]
+    assert parallelization.tiramisu_optim_str == (
+        "comp05.tag_parallel_level(1);\n"
+        "comp06.tag_parallel_level(1);\n"
+        "comp07.tag_parallel_level(1);\n"
+    )
+    assert parallelization.legality_check_string == (
+        "prepare_schedules_for_legality_checks(true);\n"
+        "    is_legal &= loop_parallelization_is_legal(1, "
+        "{&comp05, &comp06, &comp07});\n"
+        "    comp05.tag_parallel_level(1);\n"
+        "comp06.tag_parallel_level(1);\n"
+        "comp07.tag_parallel_level(1);\n"
+    )
 
 
 def test_get_candidates():

--- a/tests/tiramisu/tiramisu_actions/test_parallelization.py
+++ b/tests/tiramisu/tiramisu_actions/test_parallelization.py
@@ -13,9 +13,7 @@ def test_parallelization_init():
     assert parallelization.iterator_id == ("comp01", 1)
     assert parallelization.comps == ["comp01"]
 
-    parallelization = Parallelization(
-        [("comp01", 1)], comps=["comp01", "comp01"]
-    )
+    parallelization = Parallelization([("comp01", 1)], comps=["comp01", "comp01"])
     assert parallelization.comps == ["comp01"]
 
 

--- a/tests/tiramisu/tiramisu_actions/test_skewing.py
+++ b/tests/tiramisu/tiramisu_actions/test_skewing.py
@@ -15,6 +15,13 @@ def test_skewing_init():
     assert skewing.factors == [1, 1]
     assert skewing.comps == ["comp00"]
 
+    skewing = Skewing(
+        [("comp00", 0), ("comp00", 1), 1, 0, 1, 1], ["comp00"]
+    )
+    assert skewing.iterators == [("comp00", 0), ("comp00", 1)]
+    assert skewing.factors == [1, 0, 1, 1]
+    assert skewing.comps == ["comp00"]
+
 
 def test_initialize_action_for_tree():
     BaseConfig.init()
@@ -33,6 +40,16 @@ def test_set_string_representations():
     schedule = Schedule(sample)
     schedule.add_optimizations([skewing])
     assert skewing.tiramisu_optim_str == "comp00.skew(0, 1, 1, 1);\n"
+
+
+def test_set_string_representations_four_factors():
+    BaseConfig.init()
+    sample = test_utils.skewing_example()
+    skewing = Skewing([("comp00", 0), ("comp00", 1), 1, 0, 1, 1])
+    schedule = Schedule(sample)
+    schedule.add_optimizations([skewing])
+    assert skewing.tiramisu_optim_str == "comp00.skew(0, 1, 1, 0, 1, 1);\n"
+    assert str(skewing) == "S(L0,L1,1,0,1,1,comps=['comp00'])"
 
 
 def test_get_candidates():

--- a/tests/tiramisu/tiramisu_actions/test_skewing.py
+++ b/tests/tiramisu/tiramisu_actions/test_skewing.py
@@ -15,9 +15,7 @@ def test_skewing_init():
     assert skewing.factors == [1, 1]
     assert skewing.comps == ["comp00"]
 
-    skewing = Skewing(
-        [("comp00", 0), ("comp00", 1), 1, 0, 1, 1], ["comp00"]
-    )
+    skewing = Skewing([("comp00", 0), ("comp00", 1), 1, 0, 1, 1], ["comp00"])
     assert skewing.iterators == [("comp00", 0), ("comp00", 1)]
     assert skewing.factors == [1, 0, 1, 1]
     assert skewing.comps == ["comp00"]

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -94,6 +94,7 @@ class CompilingService:
         legality_check_lines += """
     prepare_schedules_for_legality_checks(true);
     is_legal &= check_legality_of_function();
+    is_legal &= check_legality_of_parallelism();
     std::cout << is_legal << std::endl;
 """
 
@@ -270,6 +271,9 @@ class CompilingService:
         function * fct = tiramisu::global::get_implicit_function();\n"""
         legality_cpp_code = legality_cpp_code.replace(
             "is_legal &= check_legality_of_function();", ""
+        )
+        legality_cpp_code = legality_cpp_code.replace(
+            "is_legal &= check_legality_of_parallelism();", ""
         )
         legality_cpp_code = legality_cpp_code.replace("bool is_legal=true;", "")
         legality_cpp_code = re.sub(

--- a/tiralib/tiramisu/function_server.py
+++ b/tiralib/tiramisu/function_server.py
@@ -213,6 +213,27 @@ class FunctionServer:
             f"Invalid operation {operation}. Valid operations are: execution, legality, annotations"
         )  # noqa: E501
 
+        legality_result = None
+        server_operation = operation
+        if operation == "execution" and schedule is not None:
+            # Validate subset unrolling with the specialized full-loop check,
+            # then replay the exact serialized computation subset in a fresh
+            # server process.  Tiramisu's transformed-schedule legality path
+            # cannot represent subset unrolling directly.
+            legality_result = self.run(
+                operation="legality",
+                schedule=schedule,
+                min_runs=min_runs,
+                max_runs=max_runs,
+                time_budget=time_budget,
+                delete_files=False,
+            )
+            if not legality_result.legality:
+                if delete_files:
+                    self.delete_temporary_files()
+                return legality_result
+            server_operation = "execution_no_check"
+
         env_vars = " && ".join(
             [
                 f"export {key}={value}"
@@ -227,7 +248,12 @@ class FunctionServer:
             f" && export CPATH={':'.join(BaseConfig.base_config.dependencies.includes)}"
         )
 
-        command = f'{env_vars} && cd {BaseConfig.base_config.workspace} && MIN_RUNS={min_runs} MAX_RUNS={max_runs if max_runs else "inf"} TIME_BUDGET={time_budget if time_budget else "-1"} ./{self.tiramisu_program.temp_files_identifier}_server {operation} "{schedule or ""}"'  # noqa: E501
+        if operation == "legality" and schedule is not None:
+            schedule_str = schedule.get_legality_str()
+        else:
+            schedule_str = str(schedule or "")
+
+        command = f'{env_vars} && cd {BaseConfig.base_config.workspace} && MIN_RUNS={min_runs} MAX_RUNS={max_runs if max_runs else "inf"} TIME_BUDGET={time_budget if time_budget else "-1"} ./{self.tiramisu_program.temp_files_identifier}_server {server_operation} "{schedule_str}"'  # noqa: E501
 
         # run the command and retrieve the execution status
         try:
@@ -239,7 +265,10 @@ class FunctionServer:
             raise e
         if delete_files:
             self.delete_temporary_files()
-        return ResultInterface(output)
+        result = ResultInterface(output)
+        if legality_result is not None:
+            result.legality = legality_result.legality
+        return result
 
     def get_annotations(self):
         """Run the server code to get the annotations."""

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -192,7 +192,7 @@ class Schedule:
                 if "skewing_factors" in result.additional_info:
                     for action in self.optims_list:
                         if isinstance(action, tiramisu_actions.Skewing):
-                            if action.params[2] == 0:
+                            if len(action.factors) == 2 and action.factors == [0, 0]:
                                 factors = result.additional_info.replace(
                                     "skewing_factors:", ""
                                 ).split(",")
@@ -360,14 +360,15 @@ class Schedule:
                         ]
                     )
             elif optimization_str[0] == "S":
-                regex = r"S\(L(\d),L(\d),(-?\d+),(-?\d+),comps=\[([\w', ]*)\]\)"
-                match = re.match(regex, optimization_str)
+                regex = r"S\(L(\d),L(\d),(-?\d+),(-?\d+)(?:,(-?\d+),(-?\d+))?,comps=\[([\w', ]*)\]\)"
+                match = re.fullmatch(regex, optimization_str)
                 if match:
                     outer_loop_level = int(match.group(1))
                     inner_loop_level = int(match.group(2))
-                    outer_loop_factor = int(match.group(3))
-                    inner_loop_factor = int(match.group(4))
-                    comps = match.group(5).split(",")
+                    factors = [int(match.group(3)), int(match.group(4))]
+                    if match.group(5) is not None:
+                        factors.extend([int(match.group(5)), int(match.group(6))])
+                    comps = match.group(7).split(",")
                     comps = [comp.strip("' ").strip() for comp in comps]
                     schedule.add_optimizations(
                         [
@@ -375,8 +376,7 @@ class Schedule:
                                 [
                                     (comps[0], outer_loop_level),
                                     (comps[0], inner_loop_level),
-                                    outer_loop_factor,
-                                    inner_loop_factor,
+                                    *factors,
                                 ],
                             )
                         ]

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -253,6 +253,7 @@ class Schedule:
                         [
                             tiramisu_actions.Parallelization(
                                 [(comps[0], loop_level)],
+                                comps=comps,
                             )
                         ]
                     )

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -275,6 +275,7 @@ class Schedule:
                                     (comps[0], loop_level),
                                     factor,
                                 ],
+                                comps=comps,
                             )
                         ]
                     )
@@ -454,6 +455,18 @@ class Schedule:
         sched_str = "|".join([str(optim) for optim in self.optims_list])
 
         return sched_str
+
+    def get_legality_str(self) -> str:
+        """Serialize the transformations used by the legality backend.
+
+        Most actions use their normal serialization.  Subset unrolling uses a
+        check-only full-loop representation because Tiramisu's transformed
+        legality schedule cannot express that subset directly.
+        """
+        return "|".join(
+            getattr(optim, "legality_str_representation", str(optim))
+            for optim in self.optims_list
+        )
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/tiralib/tiramisu/tiramisu_actions/parallelization.py
+++ b/tiralib/tiramisu/tiramisu_actions/parallelization.py
@@ -25,12 +25,17 @@ class Parallelization(TiramisuAction):
         # parallelize specified by a tuple (computation_name, iterator_level)
         assert len(params) == 1
         self.params = params
-        self.comps = comps
+        # Preserve the user-provided order, but make repeated computation names
+        # idempotent.  Tiramisu stores every tag_parallel_level() call, so there
+        # is no benefit in emitting the exact same (computation, level) tag more
+        # than once.
+        unique_comps = list(dict.fromkeys(comps))
+        self.comps = unique_comps
         self.iterator_id = self.params[0]
         super().__init__(
             type=TiramisuActionType.PARALLELIZATION,
             params=params,
-            comps=comps,
+            comps=unique_comps,
         )
 
     def initialize_action_for_tree(self, tiramisu_tree: TiramisuTree):
@@ -51,6 +56,8 @@ class Parallelization(TiramisuAction):
                 key=lambda comp: tiramisu_tree.computations_absolute_order[comp]
             )
 
+        self.comps = list(dict.fromkeys(self.comps))
+
         self.set_string_representations(tiramisu_tree)
 
     def set_string_representations(self, tiramisu_tree: TiramisuTree):
@@ -58,8 +65,9 @@ class Parallelization(TiramisuAction):
         assert self.comps is not None
 
         level = self.iterator_id[1]
-        first_comp = self.comps[0]
-        self.tiramisu_optim_str = f"{first_comp}.tag_parallel_level({level});\n"
+        self.tiramisu_optim_str = "".join(
+            f"{comp}.tag_parallel_level({level});\n" for comp in self.comps
+        )
 
         self.str_representation = f"P(L{level},comps={self.comps})"
 

--- a/tiralib/tiramisu/tiramisu_actions/skewing.py
+++ b/tiralib/tiramisu/tiramisu_actions/skewing.py
@@ -18,8 +18,18 @@ from tiralib.tiramisu.tiramisu_actions.tiramisu_action import (
 
 
 class Skewing(TiramisuAction):
-    """
-    Skewing optimization command.
+    """Skew two consecutive iterators ``i`` and ``j``.
+
+    The transformed iterators are::
+
+        [i']   [alpha  beta ] [i]
+        [j'] = [gamma  sigma] [j]
+
+    With two factors, ``[f_i, f_j]`` supplies the first matrix row and
+    Tiramisu computes ``gamma`` and ``sigma`` such that
+    ``f_i * sigma - f_j * gamma = 1``. With four factors,
+    ``[alpha, beta, gamma, sigma]`` supplies the complete matrix directly;
+    its determinant must have absolute value one.
     """
 
     def __init__(
@@ -27,11 +37,12 @@ class Skewing(TiramisuAction):
         params: List[IteratorIdentifier | int],
         comps: List[str] = [],
     ):
-        # Skewing takes four parameters of the form L1, L2, F3, F4
+        # Skewing takes either four parameters of the form L1, L2, f_i, f_j
+        # or six parameters of the form L1, L2, alpha, beta, gamma, sigma.
         # 1. L1 and L2 are the levels of the iterators to skew
-        # 2. F3 and F4 are the factors of the skewing
+        # 2. Two factors fill the matrix's first row; four fill it row-major.
 
-        assert len(params) == 4
+        assert len(params) in (4, 6)
         super().__init__(
             type=TiramisuActionType.SKEWING,
             params=params,
@@ -42,8 +53,8 @@ class Skewing(TiramisuAction):
         assert isinstance(params[0], tuple) and isinstance(params[1], tuple), (
             "The first two parameters must be tuples"
         )
-        assert isinstance(params[2], int) and isinstance(params[3], int), (
-            "The last two parameters must be integers"
+        assert all(isinstance(factor, int) for factor in params[2:]), (
+            "The skewing factors must be integers"
         )
 
         self.iterators: list[IteratorIdentifier] = params[:2]  # type: ignore
@@ -77,16 +88,17 @@ class Skewing(TiramisuAction):
     def set_string_representations(self, tiramisu_tree: TiramisuTree):
         assert self.iterators is not None
         assert self.comps is not None
-        assert len(self.params) == 4
+        assert len(self.params) in (4, 6)
         assert isinstance(self.iterators[0], tuple) and isinstance(
             self.iterators[1], tuple
         )
 
         self.tiramisu_optim_str = ""
+        factors_str = ", ".join(str(factor) for factor in self.factors)
         for comp in self.comps:
-            self.tiramisu_optim_str += f"{comp}.skew({self.iterators[0][1]}, {self.iterators[1][1]}, {self.factors[0]}, {self.factors[1]});\n"  # noqa: E501
+            self.tiramisu_optim_str += f"{comp}.skew({self.iterators[0][1]}, {self.iterators[1][1]}, {factors_str});\n"  # noqa: E501
 
-        self.str_representation = f"S(L{self.iterators[0][1]},L{self.iterators[1][1]},{self.factors[0]},{self.factors[1]},comps={self.comps})"  # noqa: E501
+        self.str_representation = f"S(L{self.iterators[0][1]},L{self.iterators[1][1]},{','.join(str(factor) for factor in self.factors)},comps={self.comps})"  # noqa: E501
 
         self.legality_check_string = self.tiramisu_optim_str
 

--- a/tiralib/tiramisu/tiramisu_actions/unrolling.py
+++ b/tiralib/tiramisu/tiramisu_actions/unrolling.py
@@ -33,6 +33,7 @@ class Unrolling(TiramisuAction):
 
         self.params = params
         self.comps = comps
+        self.legality_comps: List[str] = []
 
         super().__init__(type=TiramisuActionType.UNROLLING, params=params, comps=comps)
 
@@ -74,15 +75,25 @@ class Unrolling(TiramisuAction):
                 *self.iterator_id
             ).id
 
-        if not self.comps:
-            iterator = tiramisu_tree.iterators[self.iterator_id]
+        iterator = tiramisu_tree.iterators[self.iterator_id]
 
-            # Get the computations that are in the loop to be unrolled
-            self.comps = tiramisu_tree.get_iterator_subtree_computations(iterator.id)
-            # order the computations by their absolute order
-            self.comps.sort(
-                key=lambda comp: tiramisu_tree.computations_absolute_order[comp]
-            )
+        # The specialized Tiramisu legality check operates on every computation
+        # in the selected loop.  Keep that historical behavior even when a
+        # serialized schedule explicitly unrolls only a subset of them.
+        self.legality_comps = tiramisu_tree.get_iterator_subtree_computations(
+            iterator.id
+        )
+        self.legality_comps.extend(
+            comp for comp in self.comps if comp not in self.legality_comps
+        )
+        self.legality_comps.sort(
+            key=lambda comp: tiramisu_tree.computations_absolute_order[comp]
+        )
+
+        if not self.comps:
+            # Direct API calls that omit `comps` retain the original behavior:
+            # unroll the complete iterator subtree.
+            self.comps = self.legality_comps.copy()
 
         self.set_string_representations(tiramisu_tree)
 
@@ -91,38 +102,56 @@ class Unrolling(TiramisuAction):
         assert self.unrolling_factor is not None
         assert self.comps is not None
 
-        self.tiramisu_optim_str = ""
         loop_level = self.iterator_id[1]
         unrolling_factor = self.unrolling_factor
-        # for comp in self.comps:
-        unroll_lines = [
-            f"{comp}.unroll({loop_level},{unrolling_factor});" for comp in self.comps
-        ]
-        # Unrolling splits the shared loop of each computation independently,
-        # which fissions computations that were fused into one loop each. Re-issue
-        # the .after() ordering at their (now deeper) innermost loop level so
-        # codegen keeps them fused, matching the LOOPer autoscheduler (and the
-        # TiraLibCPP server path). Without this, a subset-unroll of mutually
-        # dependent computations (e.g. deriche's recursive filter) is distributed
-        # and produces wrong results.
-        if len(self.comps) > 1:
-            first = self.comps[0]
-            innermost = (
-                f"(isl_map_dim({first}.get_schedule(), isl_dim_out) - 2) / 2 - 1"
-            )
-            refusion_lines = [f"int __unroll_innermost = {innermost};"]
-            for prev, cur in zip(self.comps, self.comps[1:]):
-                refusion_lines.append(f"{cur}.after({prev}, __unroll_innermost);")
-            self.tiramisu_optim_str = (
-                "{\n    " + "\n    ".join(unroll_lines + refusion_lines) + "\n    }"
-            )
-        else:
-            self.tiramisu_optim_str = "\n    ".join(unroll_lines)
+
+        def make_optim_str(comps: List[str]) -> str:
+            unroll_lines = [
+                f"{comp}.unroll({loop_level},{unrolling_factor});" for comp in comps
+            ]
+            # Unrolling splits a shared loop independently for each computation.
+            # Re-issue the ordering for a multi-computation group so the legality
+            # path retains TiraLib's original full-subtree behavior.
+            if len(comps) > 1:
+                first = comps[0]
+                innermost = (
+                    f"(isl_map_dim({first}.get_schedule(), isl_dim_out) - 2) / 2 - 1"
+                )
+                refusion_lines = [f"int __unroll_innermost = {innermost};"]
+                for prev, cur in zip(comps, comps[1:]):
+                    refusion_lines.append(
+                        f"{cur}.after({prev}, __unroll_innermost);"
+                    )
+                return (
+                    "{\n    "
+                    + "\n    ".join(unroll_lines + refusion_lines)
+                    + "\n    }"
+                )
+            return "\n    ".join(unroll_lines)
+
+        self.tiramisu_optim_str = make_optim_str(self.comps)
         self.str_representation = (
             f"U(L{str(loop_level)},{str(unrolling_factor)},comps={self.comps})"
         )
-
-        self.legality_check_string = f"prepare_schedules_for_legality_checks(true);\n    is_legal &= loop_unrolling_is_legal({loop_level}, {{{', '.join([f'&{comp}' for comp in self.comps])}}});\n    {self.tiramisu_optim_str}"  # noqa: E501
+        legality_check = f"prepare_schedules_for_legality_checks(true);\n    is_legal &= loop_unrolling_is_legal({loop_level}, {{{', '.join([f'&{comp}' for comp in self.legality_comps])}}});"  # noqa: E501
+        if self.comps == self.legality_comps:
+            # Full-loop unrolling keeps the original TiraLib legality path,
+            # including applying the transformation before the final global
+            # dependency check.
+            self.legality_str_representation = self.str_representation
+            self.legality_check_string = (
+                f"{legality_check}\n    {self.tiramisu_optim_str}"
+            )
+        else:
+            # Tiramisu's transformed-schedule legality machinery cannot
+            # represent a subset-unrolled fused loop.  Its dedicated unrolling
+            # check can: validate the complete loop group without mutating the
+            # legality schedule, then apply the exact subset only for execution.
+            self.legality_str_representation = (
+                f"UCheck(L{str(loop_level)},{str(unrolling_factor)},"
+                f"comps={self.legality_comps})"
+            )
+            self.legality_check_string = legality_check
 
     @classmethod
     def get_candidates(cls, program_tree: TiramisuTree) -> List[IteratorIdentifier]:

--- a/tiralib/tiramisu/tiramisu_actions/unrolling.py
+++ b/tiralib/tiramisu/tiramisu_actions/unrolling.py
@@ -95,9 +95,29 @@ class Unrolling(TiramisuAction):
         loop_level = self.iterator_id[1]
         unrolling_factor = self.unrolling_factor
         # for comp in self.comps:
-        self.tiramisu_optim_str = "\n    ".join(
-            [f"{comp}.unroll({loop_level},{unrolling_factor});" for comp in self.comps]
-        )
+        unroll_lines = [
+            f"{comp}.unroll({loop_level},{unrolling_factor});" for comp in self.comps
+        ]
+        # Unrolling splits the shared loop of each computation independently,
+        # which fissions computations that were fused into one loop each. Re-issue
+        # the .after() ordering at their (now deeper) innermost loop level so
+        # codegen keeps them fused, matching the LOOPer autoscheduler (and the
+        # TiraLibCPP server path). Without this, a subset-unroll of mutually
+        # dependent computations (e.g. deriche's recursive filter) is distributed
+        # and produces wrong results.
+        if len(self.comps) > 1:
+            first = self.comps[0]
+            innermost = (
+                f"(isl_map_dim({first}.get_schedule(), isl_dim_out) - 2) / 2 - 1"
+            )
+            refusion_lines = [f"int __unroll_innermost = {innermost};"]
+            for prev, cur in zip(self.comps, self.comps[1:]):
+                refusion_lines.append(f"{cur}.after({prev}, __unroll_innermost);")
+            self.tiramisu_optim_str = (
+                "{\n    " + "\n    ".join(unroll_lines + refusion_lines) + "\n    }"
+            )
+        else:
+            self.tiramisu_optim_str = "\n    ".join(unroll_lines)
         self.str_representation = (
             f"U(L{str(loop_level)},{str(unrolling_factor)},comps={self.comps})"
         )

--- a/tiralib/tiramisu/tiramisu_actions/unrolling.py
+++ b/tiralib/tiramisu/tiramisu_actions/unrolling.py
@@ -119,13 +119,9 @@ class Unrolling(TiramisuAction):
                 )
                 refusion_lines = [f"int __unroll_innermost = {innermost};"]
                 for prev, cur in zip(comps, comps[1:]):
-                    refusion_lines.append(
-                        f"{cur}.after({prev}, __unroll_innermost);"
-                    )
+                    refusion_lines.append(f"{cur}.after({prev}, __unroll_innermost);")
                 return (
-                    "{\n    "
-                    + "\n    ".join(unroll_lines + refusion_lines)
-                    + "\n    }"
+                    "{\n    " + "\n    ".join(unroll_lines + refusion_lines) + "\n    }"
                 )
             return "\n    ".join(unroll_lines)
 


### PR DESCRIPTION
## Summary

This PR fixes several cases where a serialized schedule was reconstructed differently from what it described, or where legality was checked before the final transformed schedule was available. It also extends skew serialization without changing the existing two-factor API.

This work has matching changes in [TiraLibCpp PR #10](https://github.com/Tiramisu-Compiler/TiraLibCpp/pull/10) and depends on additions in [Tiramisu PR #422](https://github.com/Tiramisu-Compiler/tiramisu/pull/422).

## Changes

### Keep computation groups fused after unrolling

Commit [861caab](https://github.com/Mascinissa/TiraLib/commit/861caab4713ff7d4029400b82d12b5c19a8a2f0f) re-establishes the ordering of a computation group after applying `unroll()` to each member.

Calling `unroll()` separately on computations that share a loop splits that loop once per computation. Without restoring their `.after()` relationships, the transformation can turn a fused loop into several independent loops. That changes the meaning of schedules whose computations depend on one another within the loop and can cause valid group unrolls to be rejected.

The action now restores the group at its new innermost level after unrolling. A single-computation unroll is unchanged. The corresponding server-side fix is [TiraLibCpp `75f959b`](https://github.com/Mascinissa/TiraLibCpp/commit/75f959b53702fcdad9a4a92b58fdf4b86e51a3f9).

### Check parallelization against the final schedule

Commit [9ade86a](https://github.com/Mascinissa/TiraLib/commit/9ade86a20ff4691e54fdacb5ccec59138874a0fe) adds a final `check_legality_of_parallelism()` call to generated legality checks.

Parallelization is recorded on a loop level. A later interchange or tiling transformation can move a different loop into that level, so checking only when `Parallelization` is added can accept an illegal final schedule. This is the parallelize-then-interchange case reported in [issue #31](https://github.com/Tiramisu-Compiler/TiraLib/issues/31).

This change requires [Tiramisu `d7ad1e8b`](https://github.com/Mascinissa/tiramisu/commit/d7ad1e8bea84ac5faced2de36c584465770f28fa), which provides the final-schedule checker. The matching server-side change is [TiraLibCpp `e0b6be2`](https://github.com/Mascinissa/TiraLibCpp/commit/e0b6be2bbc04cc462f007b2e9dd7464fc9e65018).

### Support complete two-dimensional skew matrices

Commit [fc425d3](https://github.com/Mascinissa/TiraLib/commit/fc425d36fcc48756a824d744a73c0b951e29c68d) adds a four-factor form of `Skewing` and its schedule-string parser.

The existing form, `S(Li,Lj,alpha,beta,...)`, supplies the first row of the skew matrix and asks Tiramisu to solve for the second row. It cannot represent every valid matrix. The new form accepts the complete row-major matrix:

```text
S(Li,Lj,alpha,beta,gamma,sigma,...)

[i']   [alpha  beta ] [i]
[j'] = [gamma  sigma] [j]
```

The original two-factor syntax and automatic solver remain supported. The corresponding C++ parser change is [TiraLibCpp `067dafe`](https://github.com/Mascinissa/TiraLibCpp/commit/067dafe6607ef1a6dfb613f6f93d65d182fc8932), and the Tiramisu serializer emits this lossless form in [Tiramisu `5fc025f8`](https://github.com/Mascinissa/tiramisu/commit/5fc025f81ec40a45874b7d8a0ab208449346b668).

### Apply parallelization to every selected computation

Commit [4f16a31](https://github.com/Mascinissa/TiraLib/commit/4f16a3145dc5a5b3a272592367397a86a6b84c2d) emits `tag_parallel_level()` for every computation selected by a `Parallelization` action.

The previous implementation checked all selected computations for legality but tagged only the first one, assuming the entire group shared one fused loop. When the selection also contained independent loops, those loops remained serial and the generated program did not match the schedule. This addresses the multi-computation parallelization behavior in the Covariance case from [issue #31](https://github.com/Tiramisu-Compiler/TiraLib/issues/31).

Explicit computation lists are now preserved when parsing schedule strings, and duplicate names are removed before tags are emitted. Multiple computations in the same fused loop still generate one parallel loop. The corresponding server-side fix is [TiraLibCpp `a666990`](https://github.com/Mascinissa/TiraLibCpp/commit/a666990c9b96f396e8d9b992cbb826f0524c7245).

### Preserve explicit subset unrolling

Commit [1c7ba19](https://github.com/Mascinissa/TiraLib/commit/1c7ba1929940d89cb2d9cfa3b7bff5abc2ec35b5) keeps the computation list from a serialized `U(...)` action instead of widening it to the full iterator subtree.

The old parser read the list but did not pass it to `Unrolling`, so initialization inferred all computations below the selected iterator. A schedule that requested unrolling for one computation could therefore transform several computations.

Execution now applies unrolling only to the explicit list. Legality still checks the complete fused-loop group through Tiramisu's specialized unrolling check, without applying the subset transformation to the legality schedule. Direct API calls that omit `comps` retain the original full-subtree behavior. For server execution, a successful legality check is required before the exact subset is run in a fresh process.

The matching server protocol and action changes are in [TiraLibCpp `03d818c`](https://github.com/Mascinissa/TiraLibCpp/commit/03d818c18001d28e7095faba487103f171e4c098).

## Compatibility

- Existing two-factor skew schedule strings remain valid.
- Direct unrolling actions without an explicit computation list keep their previous full-subtree behavior.
- Single-computation unrolling is unchanged.
- Repeated computation names in parallelization actions are treated idempotently.

## Testing

- Full TiraLib test suite: 109 passed.
- Added regression coverage for final-schedule parallel legality, four-factor skew parsing, multi-computation parallelization, duplicate parallel targets, and explicit subset unrolling.
