### PR TITLE
Avoid building an ISL AST for illegal schedules

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ruff
+        python -m pip install "ruff==0.15.22"
     - name: Check formating with ruff
       run: |
         ruff format --check
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ruff
+        python -m pip install "ruff==0.15.22"
     - name: Lint with ruff
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -59,7 +59,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ruff pytest pytest-cov coverage
+        python -m pip install "ruff==0.15.22" pytest pytest-cov coverage
         if [ -f requirements.txt ]; then python -m pip install --user -r requirements.txt; fi
 
     - name: Install TiraLibCPP

--- a/tests/tiramisu/test_schedule.py
+++ b/tests/tiramisu/test_schedule.py
@@ -1,11 +1,13 @@
+from types import SimpleNamespace
+
 import pytest
 
 import tests.utils as test_utils
+from tests.utils import benchmark_program_test_sample
+from tiralib.config import BaseConfig
 from tiralib.tiramisu import tiramisu_actions
 from tiralib.tiramisu.schedule import Schedule
 from tiralib.tiramisu.tiramisu_actions.parallelization import Parallelization
-from tiralib.config import BaseConfig
-from tests.utils import benchmark_program_test_sample
 
 
 def test_execute():
@@ -103,6 +105,58 @@ def test_is_legal():
     legality = schedule.is_legal()
 
     assert legality is True
+
+
+def test_illegal_server_result_keeps_last_valid_tree():
+    BaseConfig.init()
+    test_program = benchmark_program_test_sample()
+
+    class FakeServer:
+        def run(self, *args, **kwargs):
+            return SimpleNamespace(
+                legality=False,
+                isl_ast="",
+                additional_info="",
+            )
+
+    test_program.server = FakeServer()
+    schedule = Schedule(test_program)
+    original_tree = schedule.tree
+    schedule.add_optimizations([Parallelization(params=[("comp02", 0)])])
+
+    assert schedule.is_legal() is False
+    assert schedule.tree is original_tree
+
+
+def test_legal_server_result_updates_tree_for_follow_up_actions():
+    BaseConfig.init()
+    test_program = benchmark_program_test_sample()
+
+    class FakeServer:
+        def run(self, *args, **kwargs):
+            return SimpleNamespace(
+                legality=True,
+                isl_ast=(
+                    "0|iterator|i|0|i <= 3|\n"
+                    "1|iterator|j|0|j <= 7|\n"
+                    "2|computation|comp02\n"
+                ),
+                additional_info="",
+            )
+
+    test_program.server = FakeServer()
+    schedule = Schedule(test_program)
+    schedule.add_optimizations([Parallelization(params=[("comp02", 0)])])
+
+    assert schedule.is_legal() is True
+    unrolling = tiramisu_actions.Unrolling(
+        params=[("comp02", -1), 4],
+        comps=["comp02"],
+    )
+    schedule.add_optimizations([unrolling])
+
+    assert unrolling.iterator_id == ("comp02", 1)
+    assert str(unrolling) == "U(L1,4,comps=['comp02'])"
 
 
 def test_copy():

--- a/tests/tiramisu/test_tiramisu_tree.py
+++ b/tests/tiramisu/test_tiramisu_tree.py
@@ -1,6 +1,6 @@
 import tests.utils as test_utils
-from tiralib.tiramisu.tiramisu_tree import TiramisuTree
 from tiralib.config import BaseConfig
+from tiralib.tiramisu.tiramisu_tree import TiramisuTree
 
 
 def test_from_annotations():
@@ -56,6 +56,21 @@ def test_get_candidate_computations():
         "comp03",
         "comp04",
     ]
+
+
+def test_repeated_isl_ast_computations_are_unique():
+    t_tree = TiramisuTree.from_isl_ast_string_list(
+        [
+            "0|iterator|i|0|i <= 3|",
+            "1|computation|comp00",
+            "0|iterator|i|0|i <= 3|",
+            "1|computation|comp00",
+        ]
+    )
+
+    assert t_tree.computations == ["comp00"]
+    assert t_tree.computations_absolute_order == {"comp00": 1}
+    assert t_tree.get_iterator_subtree_computations(("comp00", 0)) == ["comp00"]
 
 
 def test_get_root_of_node():

--- a/tiralib/tiramisu/compiling_service.py
+++ b/tiralib/tiramisu/compiling_service.py
@@ -55,10 +55,12 @@ class CompilingService:
             legality_result = legality_result.strip()
             if legality_result not in ["0", "1"]:
                 raise Exception(f"Error in legality check: {legality_result}")
+            if legality_result == "0":
+                return False, None
             ast = TiramisuTree.from_isl_ast_string_list(
                 isl_ast_string_list=result_lines[1:]
             )
-            return legality_result == "1", ast
+            return True, ast
 
         else:
             result = result.strip()
@@ -100,11 +102,14 @@ class CompilingService:
 
         if with_ast:
             legality_check_lines += """
-    auto fct = tiramisu::global::get_implicit_function();
+    if (is_legal)
+    {
+        auto fct = tiramisu::global::get_implicit_function();
 
-    fct->gen_time_space_domain();
-    fct->gen_isl_ast();
-    fct->print_isl_ast_representation();
+        fct->gen_time_space_domain();
+        fct->gen_isl_ast();
+        fct->print_isl_ast_representation();
+    }
 """
 
         cpp_code = schedule.tiramisu_program.cpp_code.replace(

--- a/tiralib/tiramisu/schedule.py
+++ b/tiralib/tiramisu/schedule.py
@@ -182,10 +182,16 @@ class Schedule:
 
         if self.tiramisu_program.server:
             result = self.tiramisu_program.server.run("legality", self)
-            self.tree = TiramisuTree.from_isl_ast_string_list(
-                isl_ast_string_list=result.isl_ast.split("\n")
-            )
             self.legality = result.legality
+            if result.legality:
+                if not result.isl_ast:
+                    raise RuntimeError(
+                        "The server accepted the schedule without returning "
+                        "its ISL AST."
+                    )
+                self.tree = TiramisuTree.from_isl_ast_string_list(
+                    isl_ast_string_list=result.isl_ast.split("\n")
+                )
 
             # Update the skewing factors if they are not set
             if result.additional_info:
@@ -207,8 +213,7 @@ class Schedule:
 
         assert isinstance(legality, bool)
         self.legality = legality
-        if with_ast:
-            assert new_tree
+        if with_ast and new_tree is not None:
             self.tree = new_tree
         return self.legality
 
@@ -218,6 +223,11 @@ class Schedule:
         """
         if self.tiramisu_program.server:
             result = self.tiramisu_program.server.run("legality", self)
+            if not result.legality:
+                self.legality = False
+                raise tiramisu_actions.CannotApplyException(
+                    "Cannot update the loop tree for an illegal schedule prefix."
+                )
             self.tree = TiramisuTree.from_isl_ast_string_list(
                 isl_ast_string_list=result.isl_ast.split("\n")
             )
@@ -237,6 +247,25 @@ class Schedule:
         # per-action regexes can stay strict. Tiramisu identifiers are \w+,
         # so stripping whitespace inside the schedule string is lossless.
         sched_str = re.sub(r"\s+", "", sched_str).replace('"', "'")
+
+        def normalize_computations(raw_comps: str) -> list[str]:
+            return list(
+                dict.fromkeys(comp.strip("' ") for comp in raw_comps.split(","))
+            )
+
+        def reference_computation(comps: list[str], level: int) -> str:
+            """Choose a target that exposes the serialized loop level."""
+            for comp in comps:
+                try:
+                    schedule.tree.get_iterator_of_computation(comp, level)
+                    return comp
+                except ValueError:
+                    continue
+            raise ValueError(
+                f"None of the target computations has an iterator at level "
+                f"{level}: {comps}"
+            )
+
         for optimization_str in sched_str.split("|"):
             if optimization_str == "":
                 continue
@@ -247,12 +276,12 @@ class Schedule:
                 match = re.match(regex, optimization_str)
                 if match:
                     loop_level = int(match.group(1))
-                    comps = match.group(2).split(",")
-                    comps = [comp.strip("' ") for comp in comps]
+                    comps = normalize_computations(match.group(2))
+                    reference_comp = reference_computation(comps, loop_level)
                     schedule.add_optimizations(
                         [
                             tiramisu_actions.Parallelization(
-                                [(comps[0], loop_level)],
+                                [(reference_comp, loop_level)],
                                 comps=comps,
                             )
                         ]
@@ -266,13 +295,17 @@ class Schedule:
                 if match:
                     loop_level = int(match.group(1))
                     factor = int(match.group(2))
-                    comps = match.group(3).split(",")
-                    comps = [comp.strip("' ") for comp in comps]
+                    comps = normalize_computations(match.group(3))
+                    reference_comp = (
+                        comps[0]
+                        if loop_level == -1
+                        else reference_computation(comps, loop_level)
+                    )
                     schedule.add_optimizations(
                         [
                             tiramisu_actions.Unrolling(
                                 [
-                                    (comps[0], loop_level),
+                                    (reference_comp, loop_level),
                                     factor,
                                 ],
                                 comps=comps,
@@ -285,15 +318,18 @@ class Schedule:
                 if match:
                     first_loop_level = int(match.group(1))
                     second_loop_level = int(match.group(2))
-                    comps = match.group(3).split(",")
-                    comps = [comp.strip("' ") for comp in comps]
+                    comps = normalize_computations(match.group(3))
+                    reference_comp = reference_computation(
+                        comps, max(first_loop_level, second_loop_level)
+                    )
                     schedule.add_optimizations(
                         [
                             tiramisu_actions.Interchange(
                                 [
-                                    (comps[0], first_loop_level),
-                                    (comps[0], second_loop_level),
+                                    (reference_comp, first_loop_level),
+                                    (reference_comp, second_loop_level),
                                 ],
+                                comps=comps,
                             )
                         ]
                     )
@@ -302,12 +338,13 @@ class Schedule:
                 match = re.match(regex, optimization_str)
                 if match:
                     loop_level = int(match.group(1))
-                    comps = match.group(2).split(",")
-                    comps = [comp.strip("' ") for comp in comps]
+                    comps = normalize_computations(match.group(2))
+                    reference_comp = reference_computation(comps, loop_level)
                     schedule.add_optimizations(
                         [
                             tiramisu_actions.Reversal(
-                                [(comps[0], loop_level)],
+                                [(reference_comp, loop_level)],
+                                comps=comps,
                             )
                         ]
                     )
@@ -319,17 +356,20 @@ class Schedule:
                     inner_loop_level = int(match.group(2))
                     outer_loop_factor = int(match.group(3))
                     inner_loop_factor = int(match.group(4))
-                    comps = match.group(5).split(",")
-                    comps = [comp.strip("' ").strip() for comp in comps]
+                    comps = normalize_computations(match.group(5))
+                    reference_comp = reference_computation(
+                        comps, max(outer_loop_level, inner_loop_level)
+                    )
                     schedule.add_optimizations(
                         [
                             tiramisu_actions.Tiling2D(
                                 [
-                                    (comps[0], outer_loop_level),
-                                    (comps[0], inner_loop_level),
+                                    (reference_comp, outer_loop_level),
+                                    (reference_comp, inner_loop_level),
                                     outer_loop_factor,
                                     inner_loop_factor,
                                 ],
+                                comps=comps,
                             )
                         ]
                     )
@@ -345,19 +385,27 @@ class Schedule:
                     outer_loop_factor = int(match.group(4))
                     middle_loop_factor = int(match.group(5))
                     inner_loop_factor = int(match.group(6))
-                    comps = match.group(7).split(",")
-                    comps = [comp.strip("' ").strip() for comp in comps]
+                    comps = normalize_computations(match.group(7))
+                    reference_comp = reference_computation(
+                        comps,
+                        max(
+                            outer_loop_level,
+                            middle_loop_level,
+                            inner_loop_level,
+                        ),
+                    )
                     schedule.add_optimizations(
                         [
                             tiramisu_actions.Tiling3D(
                                 [
-                                    (comps[0], outer_loop_level),
-                                    (comps[0], middle_loop_level),
-                                    (comps[0], inner_loop_level),
+                                    (reference_comp, outer_loop_level),
+                                    (reference_comp, middle_loop_level),
+                                    (reference_comp, inner_loop_level),
                                     outer_loop_factor,
                                     middle_loop_factor,
                                     inner_loop_factor,
                                 ],
+                                comps=comps,
                             )
                         ]
                     )
@@ -370,16 +418,19 @@ class Schedule:
                     factors = [int(match.group(3)), int(match.group(4))]
                     if match.group(5) is not None:
                         factors.extend([int(match.group(5)), int(match.group(6))])
-                    comps = match.group(7).split(",")
-                    comps = [comp.strip("' ").strip() for comp in comps]
+                    comps = normalize_computations(match.group(7))
+                    reference_comp = reference_computation(
+                        comps, max(outer_loop_level, inner_loop_level)
+                    )
                     schedule.add_optimizations(
                         [
                             tiramisu_actions.Skewing(
                                 [
-                                    (comps[0], outer_loop_level),
-                                    (comps[0], inner_loop_level),
+                                    (reference_comp, outer_loop_level),
+                                    (reference_comp, inner_loop_level),
                                     *factors,
                                 ],
+                                comps=comps,
                             )
                         ]
                     )

--- a/tiralib/tiramisu/tiramisu_tree.py
+++ b/tiralib/tiramisu/tiramisu_tree.py
@@ -245,7 +245,6 @@ class TiramisuTree:
             elif "|computation|" in str_line:
                 level_str, _, comp_name = str_line.split("|")
                 line_idx = int(level_str)
-                tiramisu_tree.computations.append(comp_name)
 
                 # Add the computation to its iterator's computations list
                 # (the last iterator we added in the previous level)
@@ -257,11 +256,15 @@ class TiramisuTree:
                     if comp_name not in it.computations_list:
                         it.computations_list.append(comp_name)
 
-                # Add the computation to the absolute order dict
-                tiramisu_tree.computations_absolute_order[comp_name] = (
-                    current_absolute_order
-                )
-                current_absolute_order += 1
+                # A computation may occur in several AST branches, but it is
+                # still one schedule target.  Keep its first lexical position
+                # as the absolute order and expose it only once globally.
+                if comp_name not in tiramisu_tree.computations_absolute_order:
+                    tiramisu_tree.computations.append(comp_name)
+                    tiramisu_tree.computations_absolute_order[comp_name] = (
+                        current_absolute_order
+                    )
+                    current_absolute_order += 1
         return tiramisu_tree
 
     def _get_subtree_representation(self, node_id: IteratorIdentifier) -> str:
@@ -373,7 +376,7 @@ class TiramisuTree:
         for child in candidate_node.child_iterators:
             computations += self.get_iterator_subtree_computations(child)
 
-        return computations
+        return list(dict.fromkeys(computations))
 
     def get_iterator_levels(
         self, iterators_list: list[IteratorIdentifier]


### PR DESCRIPTION
Companion server changes: [TiraLibCpp PR #11 ](https://github.com/Tiramisu-Compiler/TiraLibCpp/pull/11).

Some legality checks returned `false` quickly, then spent most of their time in `gen_isl_ast()`. Building an AST for a rejected schedule is unnecessary, and for some invalid transformed domains it can take hours or use excessive memory.

The Python compilation path now returns `(False, None)` as soon as legality fails. `Schedule.is_legal()` keeps the last valid tree in that case. Legal schedules still return an AST and update the tree as before; tree refresh remains immediate.

This also fixes duplicate computation targets during replay. A computation may appear in more than one ISL AST branch, and a serialized schedule may list the same target more than once. Tree reconstruction and schedule parsing now keep the first occurrence only.
When the first listed computation does not expose the requested loop level, the parser uses another listed computation that does.


Tests cover legal and illegal server results, preservation of the last valid tree, and repeated computations in an ISL AST.